### PR TITLE
Try to find icon with default theme if not found in theme_path

### DIFF
--- a/appIndicator.js
+++ b/appIndicator.js
@@ -318,6 +318,11 @@ const AppIndicator = new Lang.Class({
             }
             //prefer symbolic icons
             var iconinfo = icon_theme.lookup_icon(icon_name + "-panel", icon_size, Gtk.IconLookupFlags.GENERIC_FALLBACK);
+            if (iconinfo == null && theme_path) {
+                icon_theme = Gtk.IconTheme.get_default();
+                var iconinfo = icon_theme.lookup_icon(icon_name + "-panel", icon_size, Gtk.IconLookupFlags.GENERIC_FALLBACK);
+	    }
+
             if (iconinfo == null) {
                 log("FATAL: unable to lookup icon for "+icon_name);
             } else {


### PR DESCRIPTION
The patch will redo an icon lookup with the default icon theme if a custom theme path was supplied without finding the icon.

I noticed this issue when using the Solaar app. This app displays a custom icon on startup and then switches to a system icon like "battery-good-charging". It specifies a custom theme path and that results in correct loading of the custom icon, but it will fail loading the system icon. Redoing the lookup with the default theme fixes it.

This is really just a workaround and I don't fully understand the issue. If you have a better fix that would be great. To give an example this will work and return the icon:

``` javascript
var icon_theme = Gtk.IconTheme.get_default();
var icon = icon_theme.lookup_icon('battery-good-charging-panel', 40,
    Gtk.IconLookupFlags.GENERIC_FALLBACK)
```

This however will not work and will return null for the icon (and I don't understand why, looks like a bug to me):

``` javascript
var icon_theme = new Gtk.IconTheme();
icon_theme.set_search_path(Gtk.IconTheme.get_default().get_search_path());
var icon = icon_theme.lookup_icon('battery-good-charging-panel', 40,
    Gtk.IconLookupFlags.GENERIC_FALLBACK)
```
