### PR TITLE
Read prefs.js as UTF-8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ config.js: config.js.sh
 	sh config.js.sh > config.js
 
 po/messages.pot: prefs.js
-	xgettext -k_ -o po/messages.pot prefs.js
+	xgettext --from-code=UTF-8 -k_ -o po/messages.pot prefs.js
 
 schemas/gschemas.compiled: $(wildcard schemas/*.gschema.xml)
 	glib-compile-schemas schemas


### PR DESCRIPTION
In Ubuntu GNOME 14.04 (daily CD image, all packages updated as of 2014-03-29),
`make` fails with an error from `xgettext`.

This pull request fixes `Makefile` so it forces `xgettext` to read the file
`prefs.js` as UTF-8. Otherwise it defaults to ASCII, which fails.
