### PR TITLE
Middle mouse click SecondaryActivate

### DIFF
--- a/appIndicator.js
+++ b/appIndicator.js
@@ -202,6 +202,10 @@ const AppIndicator = new Lang.Class({
         this._proxy.ActivateRemote(0, 0)
     },
 
+    secondaryActivate: function () {
+        this._proxy.SecondaryActivateRemote(0, 0)
+    },
+
     scroll: function(dx, dy) {
         if (dx != 0)
             this._proxy.ScrollRemote(Math.floor(dx), 'horizontal')

--- a/indicatorStatusIcon.js
+++ b/indicatorStatusIcon.js
@@ -111,6 +111,13 @@ const IndicatorStatusIcon = new Lang.Class({
     },
     
     _boxClicked: function(actor, event) {
+        // if middle mouse button clicked send SecondaryActivate dbus event and do not show appindicator menu
+        if (event.get_button() == 2) {
+            Main.panel.menuManager._closeMenu(true, Main.panel.menuManager.activeMenu);
+            this._indicator.secondaryActivate();
+            return;
+        }
+
         //HACK: event should be a ClutterButtonEvent but we get only a ClutterEvent (why?)
         //      because we can't access click_count, we'll create our own double click detector.
         var treshold = Clutter.Settings.get_default().double_click_time;

--- a/interfaces-xml/StatusNotifierItem.xml
+++ b/interfaces-xml/StatusNotifierItem.xml
@@ -36,6 +36,10 @@
         <arg name="x" type="i" direction="in"/>
         <arg name="y" type="i" direction="in"/>
     </method>
+    <method name="SecondaryActivate">
+        <arg name="x" type="i" direction="in"/>
+        <arg name="y" type="i" direction="in"/>
+    </method>
     <method name="Scroll">
         <arg name="delta" type="i" direction="in"/>
         <arg name="dir"   type="s" direction="in"/>


### PR DESCRIPTION
Sends a SecondaryActivate dbus event to the application when single middle mouse clicking appindicator without showing the appindicator menu.