### PR TITLE
statusNotifierWatcher: seek for SNIs in the bus to ensure we have them all

### DIFF
--- a/interfaces-xml/StatusNotifierWatcher.xml
+++ b/interfaces-xml/StatusNotifierWatcher.xml
@@ -12,10 +12,10 @@
     <method name="IsNotificationHostRegistered">
         <arg type="b" direction="out" />
     </method>
-    <signal name="ServiceRegistered">
+    <signal name="StatusNotifierItemRegistered">
         <arg type="s" direction="out" />
     </signal>
-    <signal name="ServiceUnregistered">
+    <signal name="StatusNotifierItemUnregistered">
         <arg type="s" direction="out" />
     </signal>
     <property name="IsStatusNotifierHostRegistered" type="b" access="read" />

--- a/statusNotifierWatcher.js
+++ b/statusNotifierWatcher.js
@@ -125,6 +125,7 @@ const StatusNotifierWatcher = new Lang.Class({
             bus_name = invocation.get_sender();
             obj_path = service;
         } else { // we hope it is a bus name
+            bus_name = Util.getUniqueBusNameSync(invocation.get_connection(), service);
             bus_name = service;
             obj_path = DEFAULT_ITEM_OBJECT_PATH;
         }

--- a/statusNotifierWatcher.js
+++ b/statusNotifierWatcher.js
@@ -1,5 +1,6 @@
 // Copyright (C) 2011 Giovanni Campagna
 // Copyright (C) 2013-2014 Jonas Kümmerlin <rgcjonas@gmail.com>
+// Copyright (C) 2017 Canonical Ltd.
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -14,6 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
 const Gio = imports.gi.Gio
 const GLib = imports.gi.GLib
 const Gtk = imports.gi.Gtk
@@ -40,7 +42,7 @@ const WATCHER_BUS_NAME = KDE_PREFIX + '.StatusNotifierWatcher';
 const WATCHER_INTERFACE = WATCHER_BUS_NAME;
 const WATCHER_OBJECT = '/StatusNotifierWatcher';
 
-const ITEM_OBJECT = '/StatusNotifierItem';
+const DEFAULT_ITEM_OBJECT_PATH = '/StatusNotifierItem';
 
 /*
  * The StatusNotifierWatcher class implements the StatusNotifierWatcher dbus object
@@ -77,42 +79,59 @@ const StatusNotifierWatcher = new Lang.Class({
         return bus_name + obj_path;
     },
 
+    _registerItem: function(service, bus_name, obj_path) {
+        let id = this._getItemId(bus_name, obj_path);
+
+        if (this._items[id]) {
+            Util.Logger.warn("Item "+id+" is already registered");
+            return;
+        }
+
+        Util.Logger.debug("Registering StatusNotifierItem "+id);
+
+        let indicator = new AppIndicator.AppIndicator(bus_name, obj_path);
+        let visual = new IndicatorStatusIcon.IndicatorStatusIcon(indicator);
+        indicator.connect('destroy', visual.destroy.bind(visual));
+
+        this._items[id] = indicator;
+
+        this._dbusImpl.emit_signal('StatusNotifierItemRegistered', GLib.Variant.new('(s)', service));
+        this._nameWatcher[id] = Gio.DBus.session.watch_name(bus_name, Gio.BusNameWatcherFlags.NONE, null,
+                                                            this._itemVanished.bind(this));
+
+        this._dbusImpl.emit_property_changed('RegisteredStatusNotifierItems', GLib.Variant.new('as', this.RegisteredStatusNotifierItems));
+    },
+
+    _ensureItemRegistered: function(service, bus_name, obj_path) {
+        let id = this._getItemId(bus_name, obj_path);
+
+        if (this._items[id]) {
+            //delete the old one and add the new indicator
+            Util.Logger.warn("Attempting to re-register "+id+"; resetting instead");
+            this._items[id].reset();
+        }
+
+        this._registerItem(service, bus_name, obj_path)
+    },
+
     RegisterStatusNotifierItemAsync: function(params, invocation) {
         // it would be too easy if all application behaved the same
         // instead, ayatana patched gnome apps to send a path
         // while kde apps send a bus name
-        let service = params[0];
+        let [service] = params;
         let bus_name, obj_path;
+
         if (service.charAt(0) == '/') { // looks like a path
             bus_name = invocation.get_sender();
             obj_path = service;
         } else { // we hope it is a bus name
             bus_name = service;
-            obj_path = ITEM_OBJECT;
+            obj_path = DEFAULT_ITEM_OBJECT_PATH;
         }
 
-        let id = this._getItemId(bus_name, obj_path);
+        print("AppIndicatorSupport-PRINT Registering",bus_name,obj_path)
+        this._ensureItemRegistered(service, bus_name, obj_path);
 
-        if(this._items[id]) {
-            //delete the old one and add the new indicator
-            Util.Logger.warn("Attempting to re-register "+id+"; resetting instead");
-
-            this._items[id].reset();
-        } else {
-            Util.Logger.debug("Registering StatusNotifierItem "+id);
-
-            let indicator = new AppIndicator.AppIndicator(bus_name, obj_path);
-            let visual = new IndicatorStatusIcon.IndicatorStatusIcon(indicator);
-            indicator.connect('destroy', visual.destroy.bind(visual));
-
-            this._items[id] = indicator;
-
-            this._dbusImpl.emit_signal('ServiceRegistered', GLib.Variant.new('(s)', service));
-            this._nameWatcher[id] = Gio.DBus.session.watch_name(bus_name, Gio.BusNameWatcherFlags.NONE, null,
-                                                                this._itemVanished.bind(this));
-
-            this._dbusImpl.emit_property_changed('RegisteredStatusNotifierItems', GLib.Variant.new('as', this.RegisteredStatusNotifierItems));
-        }
         invocation.return_value(null);
     },
 
@@ -130,7 +149,7 @@ const StatusNotifierWatcher = new Lang.Class({
         delete this._items[id];
         Gio.DBus.session.unwatch_name(this._nameWatcher[id]);
         delete this._nameWatcher[id];
-        this._dbusImpl.emit_signal('ServiceUnregistered', GLib.Variant.new('(s)', id));
+        this._dbusImpl.emit_signal('StatusNotifierItemUnregistered', GLib.Variant.new('(s)', id));
         this._dbusImpl.emit_property_changed('RegisteredStatusNotifierItems', GLib.Variant.new('as', this.RegisteredStatusNotifierItems));
     },
 

--- a/util.js
+++ b/util.js
@@ -47,6 +47,23 @@ const refreshPropertyOnProxy = function(proxy, property_name) {
                             })
 }
 
+const getUniqueBusNameSync = function(bus, name) {
+    if (name[0] == ':')
+        return name;
+
+    if (!bus)
+        bus = Gio.DBus.session;
+
+    let variant_name = new GLib.Variant("(s)", [name]);
+    let [unique] = bus.call_sync("org.freedesktop.DBus", "/", "org.freedesktop.DBus",
+                                 "GetNameOwner", variant_name, null,
+                                 Gio.DBusCallFlags.NONE, -1, null).deep_unpack();
+
+    Logger.debug("Unique name of "+name+" is "+unique);
+
+    return unique;
+}
+
 const connectSmart3A = function(src, signal, handler) {
     let id = src.connect(signal, handler)
 

--- a/util.js
+++ b/util.js
@@ -1,4 +1,5 @@
 // Copyright (C) 2013-2014 Jonas Kümmerlin <rgcjonas@gmail.com>
+// Copyright (C) 2017 Canonical Ltd.
 //
 // This program is free software; you can redistribute it and/or
 // modify it under the terms of the GNU General Public License
@@ -51,7 +52,7 @@ const getUniqueBusNameSync = function(bus, name) {
     if (name[0] == ':')
         return name;
 
-    if (!bus)
+    if (typeof bus === "undefined" || !bus)
         bus = Gio.DBus.session;
 
     let variant_name = new GLib.Variant("(s)", [name]);
@@ -59,9 +60,78 @@ const getUniqueBusNameSync = function(bus, name) {
                                  "GetNameOwner", variant_name, null,
                                  Gio.DBusCallFlags.NONE, -1, null).deep_unpack();
 
-    Logger.debug("Unique name of "+name+" is "+unique);
-
     return unique;
+}
+
+const traverseBusNames = function(bus, cancellable, callback) {
+    if (typeof bus === "undefined" || !bus)
+        bus = Gio.DBus.session;
+
+    if (typeof(callback) !== "function")
+        throw new Error("No traversal callback provided");
+
+    bus.call("org.freedesktop.DBus", "/", "org.freedesktop.DBus",
+             "ListNames", null, new GLib.VariantType("(as)"), 0, -1, cancellable,
+             function (bus, task) {
+                if (task.had_error())
+                    return;
+
+                let [names] = bus.call_finish(task).deep_unpack();
+                let unique_names = [];
+
+                for (let name of names) {
+                    let unique = getUniqueBusNameSync(bus, name);
+                    if (unique_names.indexOf(unique) == -1)
+                        unique_names.push(unique);
+                }
+
+                for (let name of unique_names)
+                    callback(bus, name, cancellable);
+            });
+}
+
+const introspectBusObject = function(bus, name, cancellable, filterFunction, targetCallback, path) {
+    if (typeof path === "undefined" || !path)
+        path = "/";
+
+    if (typeof targetCallback !== "function")
+        throw new Error("No introspection callback defined");
+
+    bus.call (name, path, "org.freedesktop.DBus.Introspectable", "Introspect",
+              null, new GLib.VariantType("(s)"), Gio.DBusCallFlags.NONE, -1,
+              cancellable, function (bus, task) {
+                if (task.had_error())
+                    return;
+
+                let introspection = bus.call_finish(task).deep_unpack().toString();
+                let node_info = Gio.DBusNodeInfo.new_for_xml(introspection);
+
+                if ((typeof filterFunction === "function" && filterFunction(node_info) === true) ||
+                    typeof filterFunction === "undefined" || !filterFunction) {
+                    targetCallback(name, path);
+                }
+
+                if (path === "/")
+                    path = ""
+
+                for (let sub_nodes of node_info.nodes) {
+                    let sub_path = path+"/"+sub_nodes.path;
+                    introspectBusObject (bus, name, cancellable, filterFunction,
+                                         targetCallback, sub_path);
+                }
+            });
+}
+
+const dbusNodeImplementsInterfaces = function(node_info, interfaces) {
+    if (!(node_info instanceof Gio.DBusNodeInfo) || !Array.isArray(interfaces))
+        return false;
+
+    for (let iface of interfaces) {
+        if (node_info.lookup_interface(iface) !== null)
+            return true;
+    }
+
+    return false;
 }
 
 const connectSmart3A = function(src, signal, handler) {


### PR DESCRIPTION
Some indicators (*coff*, dropbox, *coff*) do not re-register again
when the plugin is enabled/disabled, thus we need to manually look
for the objects in the session bus that implements the
StatusNotifierItem interface...

This fixes issue #75, workarounding the applications problem.

Including also some other cleanups.

This won't apply to bugged apps that are confined (i.e. in snaps) since we won't be able to introspect them. The only option with these is trying to access to the standard `/StatusNotifyItem` path and see if properties are set. Less priority for now, though.