### PR TITLE
Issue #110: Fix icons vertically stretched

### DIFF
--- a/appIndicator.js
+++ b/appIndicator.js
@@ -227,7 +227,7 @@ var IconActor = new Lang.Class({
         this.height = icon_size * scale_factor
 
         this._indicator     = indicator
-        this._iconSize      = icon_size * scale_factor
+        this._iconSize      = icon_size
         this._iconCache     = new IconCache.IconCache()
 
         this._mainIcon    = new St.Bin()
@@ -335,6 +335,8 @@ var IconActor = new Lang.Class({
     },
 
     _createIconFromPixmap: function(iconSize, iconPixmapArray) {
+        let scale_factor = St.ThemeContext.get_for_stage(global.stage).scale_factor;
+        iconSize = iconSize * scale_factor
         // the pixmap actually is an array of pixmaps with different sizes
         // we use the one that is smaller or equal the iconSize
 


### PR DESCRIPTION
The scale factor on HiDPI displays only needs to be applied to pixmap indicator icons.
When the icon is obtained from the current theme then the size should be correct based on the system scaling values.
The fix was tested with a x2 scaling and x1 scaling.
Please advise on wether there is a better way of solving the problem and if my understanding is correct.