### PR TITLE
Fix the indicator-multiload

### DIFF
--- a/appIndicator.js
+++ b/appIndicator.js
@@ -236,7 +236,9 @@ var IconActor = new Lang.Class({
     _init: function(indicator, icon_size) {
         this.parent({ reactive: true })
         let scale_factor = St.ThemeContext.get_for_stage(global.stage).scale_factor;
-        this.width  = icon_size * scale_factor
+        // FIXME: Set the width is a bad idea, is we want to support not homogeneus
+        // indicator like the indicator-multiload.
+        // this.width  = icon_size * scale_factor
         this.height = icon_size * scale_factor
 
         this._indicator     = indicator
@@ -261,6 +263,17 @@ var IconActor = new Lang.Class({
             this._invalidateIcon()
     },
 
+    _getIconTvTime: function(path) {
+        try {
+            let file = Gio.file_new_for_path(path);
+            let fileInfo = file.query_info(Gio.FILE_ATTRIBUTE_TIME_MODIFIED, Gio.FileQueryInfoFlags.NONE, null);
+            if (fileInfo) {
+                return fileInfo.get_attribute_uint64(Gio.FILE_ATTRIBUTE_TIME_MODIFIED);
+            }
+        } catch (e) {}
+        return -1;
+    },
+
     // Will look the icon up in the cache, if it's found
     // it will return it. Otherwise, it will create it and cache it.
     // The .inUse flag will be set to true. So when you don't need
@@ -268,83 +281,104 @@ var IconActor = new Lang.Class({
     // and set it to false if needed so that it can be picked up by the garbage
     // collector.
     _cacheOrCreateIconByName: function(iconSize, iconName, themePath) {
-        let id = iconName + '@' + iconSize + (themePath ? '##' + themePath : '')
-
-        let icon = this._iconCache.get(id) || this._createIconByName(iconSize, iconName, themePath)
-
-        if (icon) {
-            icon.inUse = true
-            this._iconCache.add(id, icon)
+        let id = iconName + '@' + iconSize + (themePath ? '##' + themePath : '');
+        let icon = null;
+        let [path, realSize] = this._getIconInfo(iconName, themePath, iconSize);
+        if (path) {
+            let time = this._getIconTvTime(path);
+            let oldIcon = this._iconCache.get(id);
+            if (!oldIcon || (oldIcon.time < time)) {
+                this._iconCache._remove(id);
+                icon = this._createIconByName(path, iconSize);
+                icon.time = time;
+                this._iconCache.add(id, icon);
+            } else if (oldIcon) {
+                icon = oldIcon;
+            }
+            if (icon) {
+                icon.inUse = true;
+            }
         }
-
-        return icon
+        return icon;
     },
 
-    _createIconByName: function(icon_size, icon_name, themePath) {
-        // real_icon_size will contain the actual icon size in contrast to the requested icon size
-        var real_icon_size = icon_size
-        var gicon = null
+    _createIconByName: function(path, realSize) {
+        let icon = null;
+        try {
+            let pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_scale(path, -1, realSize, true);
+            icon = new St.Icon({
+                gicon: pixbuf
+            });
+            icon.set_icon_size(Math.max(pixbuf.get_width(), pixbuf.get_height()));
+            icon.set_width(pixbuf.get_width());
+            icon.set_height(pixbuf.get_height());
+        } catch (e) {
+            // the image data was probably bogus. We don't really know why, but it _does_ happen.
+            // we could log it here, but that doesn't really help in tracking it down.
+        }
+        return icon;
+    },
 
-        if (icon_name && icon_name[0] == "/") {
+    _getIconInfo: function(name, themePath, size) {
+        // assume as a default size 16px if not set.
+        if (!size)
+           size = 16;
+        // realSize will contain the actual icon size in contrast to the requested icon size.
+        let realSize = size;
+        let path = null;
+        if (name && name[0] == "/") {
             //HACK: icon is a path name. This is not specified by the api but at least inidcator-sensors uses it.
-            var [ format, width, height ] = GdkPixbuf.Pixbuf.get_file_info(icon_name)
+            let [ format, width, height ] = GdkPixbuf.Pixbuf.get_file_info(name);
             if (!format) {
-                Util.Logger.fatal("invalid image format: "+icon_name)
+                Util.Logger.fatal("invalid image format: " + name);
             } else {
                 // if the actual icon size is smaller, save that for later.
                 // scaled icons look ugly.
-                if (Math.max(width, height) < icon_size)
-                    real_icon_size = Math.max(width, height)
-
-                gicon = Gio.icon_new_for_string(icon_name)
+                if (Math.max(width, height) < size)
+                    realSize = Math.max(width, height);
+                path = name;
             }
-        } else if (icon_name) {
+        } else if (name) {
             // we manually look up the icon instead of letting st.icon do it for us
             // this allows us to sneak in an indicator provided search path and to avoid ugly upscaled icons
 
+            // indicator-application looks up a special "panel" variant, we just replicate that here
+            name = name + "-panel";
+
             // icon info as returned by the lookup
-            var icon_info = null
+            let iconInfo = null;
 
             // we try to avoid messing with the default icon theme, so we'll create a new one if needed
+            let icon_theme = null;
             if (themePath) {
-                var icon_theme = new Gtk.IconTheme()
+                icon_theme = new Gtk.IconTheme();
                 Gtk.IconTheme.get_default().get_search_path().forEach(function(path) {
-                    icon_theme.append_search_path(path)
+                    icon_theme.append_search_path(path);
                 });
-                icon_theme.append_search_path(themePath)
-                icon_theme.set_screen(imports.gi.Gdk.Screen.get_default())
+                icon_theme.append_search_path(themePath);
+                icon_theme.set_screen(imports.gi.Gdk.Screen.get_default());
             } else {
-                var icon_theme = Gtk.IconTheme.get_default()
+                icon_theme = Gtk.IconTheme.get_default();
             }
-
-            // try to look up the icon in the icon theme
-            // indicator-application looks up a special "panel" variant, we just replicate that here
-            if (icon_theme.has_icon(icon_name + "-panel")) {
-                icon_name = icon_name + "-panel"
-            }
-
-            icon_info = icon_theme.lookup_icon(icon_name, icon_size,
-                                               Gtk.IconLookupFlags.GENERIC_FALLBACK)
-
-            // no icon? that's bad!
-            if (icon_info === null) {
-                Util.Logger.fatal("unable to lookup icon for "+icon_name);
-            } else { // we have an icon
-                // the icon size may not match the requested size, especially with custom themes
-                if (icon_info.get_base_size() < icon_size) {
-                    // stretched icons look very ugly, we avoid that and just show the smaller icon
-                    real_icon_size = icon_info.get_base_size()
+            if (icon_theme) {
+                // try to look up the icon in the icon theme
+                iconInfo = icon_theme.lookup_icon(name, size,
+                                                  Gtk.IconLookupFlags.GENERIC_FALLBACK);
+                // no icon? that's bad!
+                if (iconInfo === null) {
+                    Util.Logger.fatal("unable to lookup icon for " + name);
+                } else { // we have an icon
+                    // the icon size may not match the requested size, especially with custom themes
+                    if (iconInfo.get_base_size() < size) {
+                        // stretched icons look very ugly, we avoid that and just show the smaller icon
+                        realSize = iconInfo.get_base_size();
+                     }
+                    // get the icon path
+                    path = iconInfo.get_filename();
                 }
-
-                // create a gicon for the icon
-                gicon = Gio.icon_new_for_string(icon_info.get_filename())
             }
         }
-
-        if (gicon)
-            return new St.Icon({ gicon: gicon, icon_size: real_icon_size })
-        else
-            return null
+        return [path, realSize];
     },
 
     _createIconFromPixmap: function(iconSize, iconPixmapArray) {


### PR DESCRIPTION
This is an attempt to fix the indicator-multiload, please considered it as a proposition only, as i will not adapt this pull to any of the possible suggestions. Much more things can be done to really support non homogeneous indicators, as this patch only add support for non homogeneous indicator icons in one of the two different modes to get an indicator icon and is not my intention make it general, just provide that code as an example for who want make it.

Please also note the importance to keep update the icon list base on the tv-time because in the indicator-multiload a same image name is used to have different icons. The indicator-multiload works sending a subset of images names that will be repeated but with different contents in different times.

This fix: https://github.com/ubuntu/gnome-shell-extension-appindicator/issues/92, https://github.com/ubuntu/gnome-shell-extension-appindicator/issues/121