### PR TITLE
interfaces: Explicitly convert raw data to strings

### DIFF
--- a/interfaces.js
+++ b/interfaces.js
@@ -35,6 +35,8 @@ function loadInterfaceXml(filename) {
         // Otherwise, it will try to check `instanceof XML` and fail miserably because there
         // is no `XML` on very recent SpiderMonkey releases (or, if SpiderMonkey is old enough,
         // will spit out a TypeError soon).
+        if (contents instanceof Uint8Array)
+           contents = imports.byteArray.toString(contents);
         return "<node>" + contents + "</node>"
     } else {
         throw new Error("AppIndicatorSupport: Could not load file: "+filename)


### PR DESCRIPTION
As strings are guaranteed to use UTF-8 in the GNOME platform, generic file APIs
like g_file_load_contents() return raw data instead. Since gjs' recent update to
mozjs60, this data is now returned as Uint8Array which cannot simply be treated
as string - its toString() method boils down to arr.join(',') - so use gjs' new
ByteArray module to explicitly convert the data.

Fixes: https://github.com/ubuntu/gnome-shell-extension-appindicator/issues/150