### PR TITLE
appindicators: rewrite classes using pure ES6 classes

### DIFF
--- a/appIndicator.js
+++ b/appIndicator.js
@@ -66,7 +66,7 @@ var AppIndicator = new Lang.Class({
                                           g_name: bus_name,
                                           g_object_path: object,
                                           g_flags: Gio.DBusProxyFlags.GET_INVALIDATED_PROPERTIES })
-        this._proxy.init_async(GLib.PRIORITY_DEFAULT, null, (function(initable, result) {
+        this._proxy.init_async(GLib.PRIORITY_DEFAULT, null, ((initable, result) => {
                 try {
                     initable.init_finish(result);
 
@@ -75,7 +75,7 @@ var AppIndicator = new Lang.Class({
                 } catch(e) {
                     Util.Logger.warn("While intializing proxy for "+bus_name+object+": "+e)
                 }
-            }).bind(this))
+            }))
 
         this._proxyPropertyList = interface_info.properties.map((propinfo) => { return propinfo.name })
         this._addExtraProperty('XAyatanaLabel');
@@ -166,7 +166,7 @@ var AppIndicator = new Lang.Class({
     _onPropertiesChanged: function(proxy, changed, invalidated) {
         let props = Object.keys(changed.deep_unpack())
 
-        props.forEach(function(property) {
+        props.forEach((property) => {
             // some property changes require updates on our part,
             // a few need to be passed down to the displaying code
 
@@ -308,7 +308,7 @@ var IconActor = new Lang.Class({
             // we try to avoid messing with the default icon theme, so we'll create a new one if needed
             if (themePath) {
                 var icon_theme = new Gtk.IconTheme()
-                Gtk.IconTheme.get_default().get_search_path().forEach(function(path) {
+                Gtk.IconTheme.get_default().get_search_path().forEach((path) => {
                     icon_theme.append_search_path(path)
                 });
                 icon_theme.append_search_path(themePath)
@@ -357,7 +357,7 @@ var IconActor = new Lang.Class({
         if (!iconPixmapArray || iconPixmapArray.length < 1)
             return null
 
-            let sortedIconPixmapArray = iconPixmapArray.sort(function(pixmapA, pixmapB) {
+            let sortedIconPixmapArray = iconPixmapArray.sort((pixmapA, pixmapB) => {
                 // we sort biggest to smallest
                 let areaA = pixmapA[0] * pixmapA[1]
                 let areaB = pixmapB[0] * pixmapB[1]
@@ -365,7 +365,7 @@ var IconActor = new Lang.Class({
                 return areaB - areaA
             })
 
-            let qualifiedIconPixmapArray = sortedIconPixmapArray.filter(function(pixmap) {
+            let qualifiedIconPixmapArray = sortedIconPixmapArray.filter((pixmap) => {
                 // we disqualify any pixmap that is bigger than our requested size
                 return pixmap[0] <= iconSize && pixmap[1] <= iconSize
             })

--- a/dbusMenu.js
+++ b/dbusMenu.js
@@ -178,7 +178,7 @@ const DbusMenuItem = new Lang.Class({
     },
 
     get_children: function() {
-        return this._children_ids.map(function(el) {
+        return this._children_ids.map((el) => {
             return this._client.get_item(el)
         }, this)
     },
@@ -238,7 +238,7 @@ const DBusClient = new Lang.Class({
         if (this._propertiesRequestedFor.length < 1)
             GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, this._beginRequestProperties.bind(this))
 
-        if (this._propertiesRequestedFor.filter(function(e) { return e === id }).length == 0)
+        if (this._propertiesRequestedFor.filter((e) => { return e === id }).length == 0)
             this._propertiesRequestedFor.push(id)
 
     },
@@ -258,7 +258,7 @@ const DBusClient = new Lang.Class({
         }
 
         // for some funny reason, the result array is hidden in an array
-        result[0].forEach(function([id, properties]) {
+        result[0].forEach(([id, properties]) => {
             if (!(id in this._items))
                 return
 
@@ -314,8 +314,8 @@ const DBusClient = new Lang.Class({
     _doLayoutUpdate: function(item) {
         let [ id, properties, children ] = item
 
-        let children_unpacked = children.map(function(child) { return child.deep_unpack() })
-        let children_ids = children_unpacked.map(function(child) { return child[0] })
+        let children_unpacked = children.map((child) => { return child.deep_unpack() })
+        let children_ids = children_unpacked.map((child) => { return child[0] })
 
         // make sure all our children exist
         children_unpacked.forEach(this._doLayoutUpdate, this)
@@ -349,7 +349,7 @@ const DBusClient = new Lang.Class({
             }
 
             // remove any old children that weren't reused
-            old_children_ids.forEach(function(child_id) { this._items[id].remove_child(child_id) }, this)
+            old_children_ids.forEach((child_id) => { this._items[id].remove_child(child_id) }, this)
         } else {
             // we don't, so let's create us
             this._items[id] = new DbusMenuItem(this, id, properties, children_ids)
@@ -382,12 +382,12 @@ const DBusClient = new Lang.Class({
 
     // we don't need to cache and burst-send that since it will not happen that frequently
     send_about_to_show: function(id) {
-        this._proxy.AboutToShowRemote(id, (function(result, error) {
+        this._proxy.AboutToShowRemote(id, ((result, error) => {
             if (error)
                 Util.Logger.warn("while calling AboutToShow: "+error)
             else if (result && result[0])
                 this._requestLayoutUpdate()
-        }).bind(this))
+        }))
     },
 
     send_event: function(id, event, params, timestamp) {
@@ -402,18 +402,18 @@ const DBusClient = new Lang.Class({
     },
 
     _onPropertiesUpdated: function(proxy, name, [changed, removed]) {
-        changed.forEach(function([id, props]) {
+        changed.forEach(([id, props]) => {
             if (!(id in this._items))
                 return
 
             for (let prop in props)
                 this._items[id].property_set(prop, props[prop])
         }, this)
-        removed.forEach(function([id, propNames]) {
+        removed.forEach(([id, propNames]) => {
             if (!(id in this._items))
                 return
 
-            propNames.forEach(function(propName) {
+            propNames.forEach((propName) => {
                 this._items[id].property_set(propName, null)
             }, this)
         }, this)
@@ -556,7 +556,7 @@ const MenuItemFactory = {
             MenuItemFactory._replaceSelf.call(this)
         } else {
             // find it!
-            this.menu._getMenuItems().forEach(function(item) {
+            this.menu._getMenuItems().forEach((item) => {
                 if (item._dbusItem == child)
                     item.destroy()
             })
@@ -703,7 +703,7 @@ var Client = new Lang.Class({
         this._rootItem.send_about_to_show()
 
         // fill the menu for the first time
-        this._rootItem.get_children().forEach(function(child) {
+        this._rootItem.get_children().forEach((child) => {
             this._rootMenu.addMenuItem(MenuItemFactory.createItem(this, child))
         }, this)
     },
@@ -731,7 +731,7 @@ var Client = new Lang.Class({
     _onRootChildRemoved: function(dbusItem, child) {
         // children like to play hide and seek
         // but we know how to find it for sure!
-        this._rootMenu._getMenuItems().forEach(function(item) {
+        this._rootMenu._getMenuItems().forEach((item) => {
             if (item._dbusItem == child)
                 item.destroy()
         })

--- a/dbusMenu.js
+++ b/dbusMenu.js
@@ -18,7 +18,6 @@ const Clutter = imports.gi.Clutter
 const Gio = imports.gi.Gio
 const GLib = imports.gi.GLib
 const GdkPixbuf = imports.gi.GdkPixbuf
-const Lang = imports.lang
 const PopupMenu = imports.ui.popupMenu
 const Signals = imports.signals
 const St = imports.gi.St
@@ -36,10 +35,9 @@ const Util = Extension.imports.util
 /**
  * Saves menu property values and handles type checking and defaults
  */
-const PropertyStore = new Lang.Class({
-    Name: 'DbusMenuPropertyStore',
+var PropertyStore = class AppIndicators_PropertyStore {
 
-    _init: function(initial_properties) {
+    constructor(initial_properties) {
         this._props = {}
 
         if (initial_properties) {
@@ -47,18 +45,18 @@ const PropertyStore = new Lang.Class({
                 this.set(i, initial_properties[i])
             }
         }
-    },
+    }
 
-    set: function(name, value) {
+    set(name, value) {
         if (name in PropertyStore.MandatedTypes && value && !value.is_of_type(PropertyStore.MandatedTypes[name]))
             Util.Logger.warn("Cannot set property "+name+": type mismatch!")
         else if (value)
             this._props[name] = value
         else
             delete this._props[name]
-    },
+    }
 
-    get: function(name) {
+    get(name) {
         if (name in this._props)
             return this._props[name]
         else if (name in PropertyStore.DefaultValues)
@@ -66,7 +64,7 @@ const PropertyStore = new Lang.Class({
         else
             return null
     }
-})
+};
 
 // we list all the properties we know and use here, so we won' have to deal with unexpected type mismatches
 PropertyStore.MandatedTypes = {
@@ -92,52 +90,51 @@ PropertyStore.DefaultValues = {
 /**
  * Represents a single menu item
  */
-const DbusMenuItem = new Lang.Class({
-    Name: 'DbusMenuItem',
+var DbusMenuItem = class AppIndicators_DbusMenuItem {
 
     // will steal the properties object
-    _init: function(client, id, properties, children_ids) {
+    constructor(client, id, properties, children_ids) {
         this._client = client
         this._id = id
         this._propStore = new PropertyStore(properties)
         this._children_ids = children_ids
-    },
+    }
 
-    property_get: function(prop_name) {
+    property_get(prop_name) {
         let prop = this.property_get_variant(prop_name)
         return prop ? prop.get_string()[0] : null
-    },
+    }
 
-    property_get_variant: function(prop_name) {
+    property_get_variant(prop_name) {
         return this._propStore.get(prop_name)
-    },
+    }
 
-    property_get_bool: function(prop_name) {
+    property_get_bool(prop_name) {
         let prop  = this.property_get_variant(prop_name)
         return prop ? prop.get_boolean() : false
-    },
+    }
 
-    property_get_int: function(prop_name) {
+    property_get_int(prop_name) {
         let prop = this.property_get_variant(prop_name)
         return prop ? prop.get_int32() : 0
-    },
+    }
 
-    property_set: function(prop, value) {
+    property_set(prop, value) {
         this._propStore.set(prop, value)
 
         this.emit('property-changed', prop, this.property_get_variant(prop))
-    },
+    }
 
-    get_children_ids: function() {
+    get_children_ids() {
         return this._children_ids.concat() // clone it!
-    },
+    }
 
-    add_child: function(pos, child_id) {
+    add_child(pos, child_id) {
         this._children_ids.splice(pos, 0, child_id)
         this.emit('child-added', this._client.get_item(child_id), pos)
-    },
+    }
 
-    remove_child: function(child_id) {
+    remove_child(child_id) {
         // find it
         let pos = -1
         for (let i = 0; i < this._children_ids.length; ++i) {
@@ -153,9 +150,9 @@ const DbusMenuItem = new Lang.Class({
             this._children_ids.splice(pos, 1)
             this.emit('child-removed', this._client.get_item(child_id))
         }
-    },
+    }
 
-    move_child: function(child_id, newpos) {
+    move_child(child_id, newpos) {
         // find the old position
         let oldpos = -1
         for (let i = 0; i < this._children_ids.length; ++i) {
@@ -175,29 +172,29 @@ const DbusMenuItem = new Lang.Class({
             this._children_ids.splice(newpos, 0, child_id)
             this.emit('child-moved', oldpos, newpos, this._client.get_item(child_id))
         }
-    },
+    }
 
-    get_children: function() {
+    get_children() {
         return this._children_ids.map((el) => {
             return this._client.get_item(el)
         }, this)
-    },
+    }
 
-    handle_event: function(event, data, timestamp) {
+    handle_event(event, data, timestamp) {
         if (!data)
             data = GLib.Variant.new_int32(0)
 
         this._client.send_event(this._id, event, data, timestamp)
-    },
+    }
 
-    get_id: function() {
+    get_id() {
         return this._id
-    },
+    }
 
-    send_about_to_show: function() {
+    send_about_to_show() {
         this._client.send_about_to_show(this._id)
     }
-})
+}
 Signals.addSignalMethods(DbusMenuItem.prototype)
 
 
@@ -206,10 +203,9 @@ const BusClientProxy = Gio.DBusProxy.makeProxyWrapper(DBusInterfaces.DBusMenu);
 /**
  * The client does the heavy lifting of actually reading layouts and distributing events
  */
-const DBusClient = new Lang.Class({
-    Name: 'DbusMenuBusClient',
+var DBusClient = class AppIndicators_DBusClient {
 
-    _init: function(busName, busPath) {
+    constructor(busName, busPath) {
         this._proxy = new BusClientProxy(Gio.DBus.session, busName, busPath, this._clientReady.bind(this))
         this._items = { 0: new DbusMenuItem(this, 0, { 'children-display': GLib.Variant.new_string('submenu') }, []) }
 
@@ -220,20 +216,20 @@ const DBusClient = new Lang.Class({
 
         // property requests are queued
         this._propertiesRequestedFor = [ /* ids */ ]
-    },
+    }
 
-    get_root: function() {
+    get_root() {
         return this._items[0]
-    },
+    }
 
-    _requestLayoutUpdate: function() {
+    _requestLayoutUpdate() {
         if (this._flagLayoutUpdateInProgress)
             this._flagLayoutUpdateRequired = true
         else
             this._beginLayoutUpdate()
-    },
+    }
 
-    _requestProperties: function(id) {
+    _requestProperties(id) {
         // if we don't have any requests queued, we'll need to add one
         if (this._propertiesRequestedFor.length < 1)
             GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, this._beginRequestProperties.bind(this))
@@ -241,17 +237,17 @@ const DBusClient = new Lang.Class({
         if (this._propertiesRequestedFor.filter((e) => { return e === id }).length == 0)
             this._propertiesRequestedFor.push(id)
 
-    },
+    }
 
-    _beginRequestProperties: function() {
+    _beginRequestProperties() {
         this._proxy.GetGroupPropertiesRemote(this._propertiesRequestedFor, [], this._endRequestProperties.bind(this))
 
         this._propertiesRequestedFor = []
 
         return false
-    },
+    }
 
-    _endRequestProperties: function(result, error) {
+    _endRequestProperties(result, error) {
         if (error) {
             Util.Logger.warn("Could not retrieve properties: "+error)
             return
@@ -265,11 +261,11 @@ const DBusClient = new Lang.Class({
             for (let prop in properties)
                 this._items[id].property_set(prop, properties[prop])
         }, this)
-    },
+    }
 
     // Traverses the list of cached menu items and removes everyone that is not in the list
     // so we don't keep alive unused items
-    _gcItems: function() {
+    _gcItems() {
         let tag = new Date().getTime()
 
         let toTraverse = [ 0 ]
@@ -282,20 +278,20 @@ const DBusClient = new Lang.Class({
         for (let i in this._items)
             if (this._items[i]._dbusClientGcTag != tag)
                 delete this._items[i]
-    },
+    }
 
     // the original implementation will only request partial layouts if somehow possible
     // we try to save us from multiple kinds of race conditions by always requesting a full layout
-    _beginLayoutUpdate: function() {
+    _beginLayoutUpdate() {
         // we only read the type property, because if the type changes after reading all properties,
         // the view would have to replace the item completely which we try to avoid
         this._proxy.GetLayoutRemote(0, -1, [ 'type', 'children-display' ], this._endLayoutUpdate.bind(this))
 
         this._flagLayoutUpdateRequired = false
         this._flagLayoutUpdateInProgress = true
-    },
+    }
 
-    _endLayoutUpdate: function(result, error) {
+    _endLayoutUpdate(result, error) {
         if (error) {
             Util.Logger.warn("While reading menu layout on proxy '"+this._proxy.g_name_owner+": "+error)
             return
@@ -309,9 +305,9 @@ const DBusClient = new Lang.Class({
             this._beginLayoutUpdate()
         else
             this._flagLayoutUpdateInProgress = false
-    },
+    }
 
-    _doLayoutUpdate: function(item) {
+    _doLayoutUpdate(item) {
         let [ id, properties, children ] = item
 
         let children_unpacked = children.map((child) => { return child.deep_unpack() })
@@ -357,9 +353,9 @@ const DBusClient = new Lang.Class({
         }
 
         return id
-    },
+    }
 
-    _clientReady: function(result, error) {
+    _clientReady(result, error) {
         if (error) {
             Util.Logger.warn("Could not initialize menu proxy: "+error)
             //FIXME: show message to the user?
@@ -370,38 +366,38 @@ const DBusClient = new Lang.Class({
         // listen for updated layouts and properties
         this._proxy.connectSignal("LayoutUpdated", this._onLayoutUpdated.bind(this))
         this._proxy.connectSignal("ItemsPropertiesUpdated", this._onPropertiesUpdated.bind(this))
-    },
+    }
 
-    get_item: function(id) {
+    get_item(id) {
         if (id in this._items)
             return this._items[id]
 
         Util.Logger.warn("trying to retrieve item for non-existing id "+id+" !?")
         return null
-    },
+    }
 
     // we don't need to cache and burst-send that since it will not happen that frequently
-    send_about_to_show: function(id) {
+    send_about_to_show(id) {
         this._proxy.AboutToShowRemote(id, ((result, error) => {
             if (error)
                 Util.Logger.warn("while calling AboutToShow: "+error)
             else if (result && result[0])
                 this._requestLayoutUpdate()
         }))
-    },
+    }
 
-    send_event: function(id, event, params, timestamp) {
+    send_event(id, event, params, timestamp) {
         if (!this._proxy)
             return
 
         this._proxy.EventRemote(id, event, params, timestamp, function(result, error) { /* we don't care */ })
-    },
+    }
 
-    _onLayoutUpdated: function() {
+    _onLayoutUpdated() {
         this._requestLayoutUpdate()
-    },
+    }
 
-    _onPropertiesUpdated: function(proxy, name, [changed, removed]) {
+    _onPropertiesUpdated(proxy, name, [changed, removed]) {
         changed.forEach(([id, props]) => {
             if (!(id in this._items))
                 return
@@ -417,16 +413,16 @@ const DBusClient = new Lang.Class({
                 this._items[id].property_set(propName, null)
             }, this)
         }, this)
-    },
+    }
 
-    destroy: function() {
+    destroy() {
         this.emit('destroy')
 
         Signals._disconnectAll.apply(this._proxy)
 
         this._proxy = null
     }
-})
+}
 Signals.addSignalMethods(DBusClient.prototype)
 
 //////////////////////////////////////////////////////////////////////////
@@ -493,7 +489,7 @@ const MenuItemFactory = {
         return shellItem
     },
 
-    _onOpenStateChanged: function(menu, open) {
+    _onOpenStateChanged(menu, open) {
         if (open) {
             if (NEED_NESTED_SUBMENU_FIX) {
                 // close our own submenus
@@ -520,11 +516,11 @@ const MenuItemFactory = {
         }
     },
 
-    _onActivate: function() {
+    _onActivate() {
         this._dbusItem.handle_event("clicked", GLib.Variant.new("i", 0), 0)
     },
 
-    _onPropertyChanged: function(dbusItem, prop, value) {
+    _onPropertyChanged(dbusItem, prop, value) {
         if (prop == "toggle-type" || prop == "toggle-state")
             MenuItemFactory._updateOrnament.call(this)
         else if (prop == "label")
@@ -541,7 +537,7 @@ const MenuItemFactory = {
         //    Util.Logger.debug("Unhandled property change: "+prop)
     },
 
-    _onChildAdded: function(dbusItem, child, position) {
+    _onChildAdded(dbusItem, child, position) {
         if (!(this instanceof PopupMenu.PopupSubMenuMenuItem)) {
             Util.Logger.warn("Tried to add a child to non-submenu item. Better recreate it as whole")
             MenuItemFactory._replaceSelf.call(this)
@@ -550,7 +546,7 @@ const MenuItemFactory = {
         }
     },
 
-    _onChildRemoved: function(dbusItem, child) {
+    _onChildRemoved(dbusItem, child) {
         if (!(this instanceof PopupMenu.PopupSubMenuMenuItem)) {
             Util.Logger.warn("Tried to remove a child from non-submenu item. Better recreate it as whole")
             MenuItemFactory._replaceSelf.call(this)
@@ -563,7 +559,7 @@ const MenuItemFactory = {
         }
     },
 
-    _onChildMoved: function(dbusItem, child, oldpos, newpos) {
+    _onChildMoved(dbusItem, child, oldpos, newpos) {
         if (!(this instanceof PopupMenu.PopupSubMenuMenuItem)) {
             Util.Logger.warn("Tried to move a child in non-submenu item. Better recreate it as whole")
             MenuItemFactory._replaceSelf.call(this)
@@ -572,14 +568,14 @@ const MenuItemFactory = {
         }
     },
 
-    _updateLabel: function() {
+    _updateLabel() {
         let label = this._dbusItem.property_get("label").replace(/_([^_])/, "$1")
 
         if (this.label) // especially on GS3.8, the separator item might not even have a hidden label
             this.label.set_text(label)
     },
 
-    _updateOrnament: function() {
+    _updateOrnament() {
         if (!this.setOrnament) return // separators and alike might not have gotten the polyfill
 
         if (this._dbusItem.property_get("toggle-type") == "checkmark" && this._dbusItem.property_get_int("toggle-state"))
@@ -590,7 +586,7 @@ const MenuItemFactory = {
             this.setOrnament(PopupMenu.Ornament.NONE)
     },
 
-    _updateImage: function() {
+    _updateImage() {
         if (!this._icon) return // might be missing on submenus / separators
 
         let iconName = this._dbusItem.property_get("icon-name")
@@ -601,15 +597,15 @@ const MenuItemFactory = {
             this._icon.gicon = GdkPixbuf.Pixbuf.new_from_stream(Gio.MemoryInputStream.new_from_bytes(iconData.get_data_as_bytes()), null)
     },
 
-    _updateVisible: function() {
+    _updateVisible() {
         this.actor.visible = this._dbusItem.property_get_bool("visible")
     },
 
-    _updateSensitive: function() {
+    _updateSensitive() {
         this.setSensitive(this._dbusItem.property_get_bool("enabled"))
     },
 
-    _replaceSelf: function(newSelf) {
+    _replaceSelf(newSelf) {
         // create our new self if needed
         if (!newSelf)
             newSelf = MenuItemFactory.createItem(this._dbusClient, this._dbusItem)
@@ -638,7 +634,7 @@ const MenuItemFactory = {
  * Utility functions not necessarily belonging into the item factory
  */
 const MenuUtils = {
-    moveItemInMenu: function(menu, dbusItem, newpos) {
+    moveItemInMenu(menu, dbusItem, newpos) {
         //HACK: we're really getting into the internals of the PopupMenu implementation
 
         // First, find our wrapper. Children tend to lie. We do not trust the old positioning.
@@ -667,21 +663,19 @@ const MenuUtils = {
  *
  * Something like a mini-god-object
  */
-var Client = new Lang.Class({
-    Name: 'DbusMenuClient',
+var Client = class AppIndicators_Client {
 
-    _init: function(busName, path) {
-        this.parent()
+    constructor(busName, path) {
         this._busName  = busName
         this._busPath  = path
         this._client   = new DBusClient(busName, path)
         this._rootMenu = null // the shell menu
         this._rootItem = null // the DbusMenuItem for the root
-    },
+    }
 
     // this will attach the client to an already existing menu that will be used as the root menu.
     // it will also connect the client to be automatically destroyed when the menu dies.
-    attachToMenu: function(menu) {
+    attachToMenu(menu) {
         this._rootMenu = menu
         this._rootItem = this._client.get_root()
 
@@ -706,9 +700,9 @@ var Client = new Lang.Class({
         this._rootItem.get_children().forEach((child) => {
             this._rootMenu.addMenuItem(MenuItemFactory.createItem(this, child))
         }, this)
-    },
+    }
 
-    _setOpenedSubmenu: function(submenu) {
+    _setOpenedSubmenu(submenu) {
         if (!submenu)
             return
 
@@ -722,26 +716,26 @@ var Client = new Lang.Class({
             this._openedSubMenu.close(true)
 
         this._openedSubMenu = submenu
-    },
+    }
 
-    _onRootChildAdded: function(dbusItem, child, position) {
+    _onRootChildAdded(dbusItem, child, position) {
         this._rootMenu.addMenuItem(MenuItemFactory.createItem(this, child), position)
-    },
+    }
 
-    _onRootChildRemoved: function(dbusItem, child) {
+    _onRootChildRemoved(dbusItem, child) {
         // children like to play hide and seek
         // but we know how to find it for sure!
         this._rootMenu._getMenuItems().forEach((item) => {
             if (item._dbusItem == child)
                 item.destroy()
         })
-    },
+    }
 
-    _onRootChildMoved: function(dbusItem, child, oldpos, newpos) {
+    _onRootChildMoved(dbusItem, child, oldpos, newpos) {
         MenuUtils.moveItemInMenu(this._rootMenu, dbusItem, newpos)
-    },
+    }
 
-    _onMenuOpened: function(menu, state) {
+    _onMenuOpened(menu, state) {
         if (!this._rootItem) return
 
         if (state) {
@@ -753,9 +747,9 @@ var Client = new Lang.Class({
         } else {
             this._rootItem.handle_event("closed", null, 0)
         }
-    },
+    }
 
-    destroy: function() {
+    destroy() {
         this.emit('destroy')
 
         if (this._client)
@@ -765,5 +759,5 @@ var Client = new Lang.Class({
         this._rootItem = null
         this._rootMenu = null
     }
-})
+}
 Signals.addSignalMethods(Client.prototype)

--- a/extension.js
+++ b/extension.js
@@ -34,7 +34,7 @@ function init() {
     if (typeof global['--appindicator-extension-on-reload'] == 'function')
         global['--appindicator-extension-on-reload']()
 
-    global['--appindicator-extension-on-reload'] = function() {
+    global['--appindicator-extension-on-reload'] = () => {
         Util.Logger.debug("Reload detected, destroying old watchdog")
         NameWatchdog.destroy()
     }

--- a/extension.js
+++ b/extension.js
@@ -23,10 +23,11 @@ const Util = Extension.imports.util
 
 let statusNotifierWatcher = null;
 let isEnabled = false;
+let watchDog = null;
 
 function init() {
-    NameWatchdog.init();
-    NameWatchdog.onVanished = maybe_enable_after_name_available;
+    watchDog = new NameWatchdog();
+    watchDog.onVanished = maybe_enable_after_name_available;
 
     //HACK: we want to leave the watchdog alive when disabling the extension,
     // but if we are being reloaded, we destroy it since it could be considered
@@ -36,7 +37,7 @@ function init() {
 
     global['--appindicator-extension-on-reload'] = () => {
         Util.Logger.debug("Reload detected, destroying old watchdog")
-        NameWatchdog.destroy()
+        watchDog.destroy();
     }
 }
 
@@ -46,7 +47,7 @@ function init() {
 // monitor the bus manually to find out when the name vanished so we can reclaim it again.
 function maybe_enable_after_name_available() {
     // by the time we get called whe might not be enabled
-    if (isEnabled && !NameWatchdog.isPresent && statusNotifierWatcher === null)
+    if (isEnabled && !watchDog.isPresent && statusNotifierWatcher === null)
         statusNotifierWatcher = new StatusNotifierWatcher.StatusNotifierWatcher();
 }
 
@@ -66,29 +67,29 @@ function disable() {
 /**
  * NameWatchdog will monitor the ork.kde.StatusNotifierWatcher bus name for us
  */
-const NameWatchdog = {
-    onAppeared: null,
-    onVanished: null,
+var NameWatchdog = class AppIndicators_NameWatchdog {
 
-    _watcher_id: null,
+    constructor() {
+        this.onAppeared = null;
+        this.onVanished = null;
 
-    isPresent: false, //will be set in the handlers which are guaranteed to be called at least once
+        // will be set in the handlers which are guaranteed to be called at least once
+        this.isPresent = false;
 
-    init: function() {
         this._watcher_id = Gio.DBus.session.watch_name("org.kde.StatusNotifierWatcher", 0,
             this._appeared_handler.bind(this), this._vanished_handler.bind(this));
-    },
+    }
 
-    destroy: function() {
+    destroy() {
         Gio.DBus.session.unwatch_name(this._watcher_id);
-    },
+    }
 
-    _appeared_handler: function() {
+    _appeared_handler() {
         this.isPresent = true;
         if (this.onAppeared) this.onAppeared();
-    },
+    }
 
-    _vanished_handler: function() {
+    _vanished_handler() {
         this.isPresent = false;
         if (this.onVanished) this.onVanished();
     }

--- a/iconCache.js
+++ b/iconCache.js
@@ -17,7 +17,6 @@
 const GLib = imports.gi.GLib
 const GObject = imports.gi.GObject
 
-const Lang = imports.lang
 const Mainloop = imports.mainloop
 
 const Util = imports.misc.extensionUtils.getCurrentExtension().imports.util;
@@ -32,16 +31,14 @@ const LIFETIME_TIMESPAN = 5000; // milli-seconds
 const GC_INTERVAL = 10; // seconds
 
 // how to use: see IconCache.add, IconCache.get
-var IconCache = new Lang.Class({
-    Name: 'IconCache',
-
-    _init: function() {
+var IconCache = class AppIndicators_IconCache {
+    constructor() {
         this._cache = {};
         this._lifetime = {}; //we don't want to attach lifetime to the object
         this._destroyNotify = {};
-    },
+    }
 
-    add: function(id, o) {
+    add(id, o) {
         if (!(o && id))
             return null;
 
@@ -62,9 +59,9 @@ var IconCache = new Lang.Class({
         this._checkGC();
 
         return o;
-    },
+    }
 
-    _remove: function(id) {
+    _remove(id) {
         if (!(id in this._cache))
             return;
 
@@ -83,27 +80,27 @@ var IconCache = new Lang.Class({
         delete this._destroyNotify[id];
 
         this._checkGC();
-    },
+    }
 
-    _renewLifetime: function(id) {
+    _renewLifetime(id) {
         if (id in this._cache)
             this._lifetime[id] = new Date().getTime() + LIFETIME_TIMESPAN;
-    },
+    }
 
-    forceDestroy: function(id) {
+    forceDestroy(id) {
         this._remove(id);
-    },
+    }
 
     // removes everything from the cache
-    clear: function() {
+    clear() {
         for (let id in this._cache)
             this._remove(id)
 
         this._checkGC();
-    },
+    }
 
     // returns an object from the cache, or null if it can't be found.
-    get: function(id) {
+    get(id) {
         if (id in this._cache) {
             //Util.Logger.debug('IconCache: retrieving '+id);
             this._renewLifetime(id);
@@ -111,9 +108,9 @@ var IconCache = new Lang.Class({
         }
 
         return null;
-    },
+    }
 
-    _checkGC: function() {
+    _checkGC() {
         let cacheIsEmpty = (Object.keys(this._cache).length === 0);
 
         if (!cacheIsEmpty && !this._gcTimeout) {
@@ -125,9 +122,9 @@ var IconCache = new Lang.Class({
             GLib.Source.remove(this._gcTimeout);
             this._gcTimeout = 0;
         }
-    },
+    }
 
-    _gc: function() {
+    _gc() {
         var time = new Date().getTime();
         for (var id in this._cache) {
             if (this._cache[id].inUse) {
@@ -141,9 +138,9 @@ var IconCache = new Lang.Class({
         }
 
         return true;
-    },
+    }
 
-    destroy: function() {
+    destroy() {
         this.clear();
     }
-});
+};

--- a/indicator-test-tool/testTool.js
+++ b/indicator-test-tool/testTool.js
@@ -9,7 +9,7 @@ const Gtk = imports.gi.Gtk;
 const AppIndicator = imports.gi.AppIndicator3;
 const GLib = imports.gi.GLib;
 
-(function() {
+(() => {
 
 var app = new Gtk.Application({
     application_id: null
@@ -17,11 +17,11 @@ var app = new Gtk.Application({
 
 var window = null;
 
-app.connect("activate", function(){
+app.connect("activate", () => {
     window.present();
 });
 
-app.connect("startup", function() {
+app.connect("startup", () => {
     window = new Gtk.ApplicationWindow({
         title: "test",
         application: app
@@ -97,13 +97,13 @@ app.connect("startup", function() {
     menu.append(item);
 
     item = Gtk.MenuItem.new_with_label("Set Label");
-    item.connect('activate', function() {
+    item.connect('activate', () => {
         indicator.set_label(''+new Date().getSeconds(), 'Blub');
     });
     menu.append(item);
 
     item = Gtk.MenuItem.new_with_label("Unset Label");
-    item.connect('activate', function() {
+    item.connect('activate', () => {
         indicator.set_label('', '');
     })
     menu.append(item);
@@ -112,9 +112,9 @@ app.connect("startup", function() {
     menu.append(item);
 
     item = Gtk.MenuItem.new_with_label("Hide for some time");
-    item.connect('activate', function() {
+    item.connect('activate', () => {
         indicator.set_status(AppIndicator.IndicatorStatus.PASSIVE);
-        GLib.timeout_add(0, 5000, function() {
+        GLib.timeout_add(0, 5000, () => {
             indicator.set_status(AppIndicator.IndicatorStatus.ACTIVE);
             return false;
         });
@@ -122,8 +122,8 @@ app.connect("startup", function() {
     menu.append(item);
 
     item = Gtk.MenuItem.new_with_label("Close in 5 seconds");
-    item.connect('activate', function() {
-        GLib.timeout_add(0, 5000, function() {
+    item.connect('activate', () => {
+        GLib.timeout_add(0, 5000, () => {
             app.quit();
             return false;
         });

--- a/indicatorStatusIcon.js
+++ b/indicatorStatusIcon.js
@@ -14,9 +14,9 @@
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 const Clutter = imports.gi.Clutter;
+const GObject = imports.gi.GObject;
 const St = imports.gi.St;
 
-const Lang = imports.lang;
 const Main = imports.ui.main;
 const Panel = imports.ui.panel;
 const PanelMenu = imports.ui.panelMenu;
@@ -31,13 +31,10 @@ const Util = Extension.imports.util;
 /*
  * IndicatorStatusIcon implements an icon in the system status area
  */
-var IndicatorStatusIcon = new Lang.Class({
-    Name: 'IndicatorStatusIcon',
-    Extends: PanelMenu.Button,
-
-    _init: function(indicator) {
-        this.parent(null, 'FIXME'); //no name yet (?)
-
+var IndicatorStatusIcon = GObject.registerClass(
+class AppIndicators_IndicatorStatusIcon extends PanelMenu.Button {
+    _init(indicator) {
+        super._init(null, indicator._uniqueId);
         this._indicator = indicator;
 
         this._iconBox = new AppIndicator.IconActor(indicator, Panel.PANEL_ICON_SIZE + 6);
@@ -61,9 +58,9 @@ var IndicatorStatusIcon = new Lang.Class({
 
         if (this._indicator.isReady)
             this._display()
-    },
+    }
 
-    _updateLabel: function() {
+    _updateLabel() {
         var label = this._indicator.label;
         if (label) {
             if (!this._label || !this._labelBin) {
@@ -83,16 +80,16 @@ var IndicatorStatusIcon = new Lang.Class({
                 delete this._label;
             }
         }
-    },
+    }
 
-    _updateStatus: function() {
+    _updateStatus() {
         if (this._indicator.status != AppIndicator.SNIStatus.PASSIVE)
             this.actor.show()
         else
             this.actor.hide()
-    },
+    }
 
-    _display: function() {
+    _display() {
         this._updateLabel()
         this._updateStatus()
 
@@ -102,9 +99,9 @@ var IndicatorStatusIcon = new Lang.Class({
         }
 
         Main.panel.addToStatusArea("appindicator-"+this._indicator.uniqueId, this, 1, 'right')
-    },
+    }
 
-    _boxClicked: function(actor, event) {
+    _boxClicked(actor, event) {
         // if middle mouse button clicked send SecondaryActivate dbus event and do not show appindicator menu
         if (event.get_button() == 2) {
             Main.panel.menuManager._closeMenu(true, Main.panel.menuManager.activeMenu);

--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,9 @@
 {
-    "shell-version": ["3.16", "3.17.91", "3.18", "3.20", "3.22", "3.24", "3.26"],
+    "shell-version": [
+        "3.30",
+        "3.31",
+        "3.32"
+    ],
     "uuid": "appindicatorsupport@rgcjonas.gmail.com",
     "name": "KStatusNotifierItem/AppIndicator Support",
     "description": "Adds KStatusNotifierItem support to the Shell",

--- a/statusNotifierWatcher.js
+++ b/statusNotifierWatcher.js
@@ -18,7 +18,6 @@ const Gio = imports.gi.Gio
 const GLib = imports.gi.GLib
 const Gtk = imports.gi.Gtk
 
-const Lang = imports.lang
 const Mainloop = imports.mainloop
 const ShellConfig = imports.misc.config
 const Signals = imports.signals
@@ -43,42 +42,41 @@ const DEFAULT_ITEM_OBJECT_PATH = '/StatusNotifierItem';
 /*
  * The StatusNotifierWatcher class implements the StatusNotifierWatcher dbus object
  */
-var StatusNotifierWatcher = new Lang.Class({
-    Name: 'StatusNotifierWatcher',
+var StatusNotifierWatcher = class AppIndicators_StatusNotifierWatcher {
 
-    _init: function() {
+    constructor() {
         this._dbusImpl = Gio.DBusExportedObject.wrapJSObject(Interfaces.StatusNotifierWatcher, this);
         this._dbusImpl.export(Gio.DBus.session, WATCHER_OBJECT);
         this._cancellable = new Gio.Cancellable;
         this._everAcquiredName = false;
         this._ownName = Gio.DBus.session.own_name(WATCHER_BUS_NAME,
-                                  Gio.BusNameOwnerFlags.NONE,
-                                  Lang.bind(this, this._acquiredName),
-                                  Lang.bind(this, this._lostName));
+                                                  Gio.BusNameOwnerFlags.NONE,
+                                                  this._acquiredName.bind(this),
+                                                  this._lostName.bind(this));
         this._items = { };
         this._nameWatcher = { };
 
         this._seekStatusNotifierItems();
     }
 
-    _acquiredName: function() {
+    _acquiredName() {
         this._everAcquiredName = true;
-    },
+    }
 
-    _lostName: function() {
+    _lostName() {
         if (this._everAcquiredName)
             Util.Logger.debug('Lost name' + WATCHER_BUS_NAME);
         else
             Util.Logger.warn('Failed to acquire ' + WATCHER_BUS_NAME);
-    },
+    }
 
 
     // create a unique index for the _items dictionary
-    _getItemId: function(bus_name, obj_path) {
+    _getItemId(bus_name, obj_path) {
         return bus_name + obj_path;
-    },
+    }
 
-    _registerItem: function(service, bus_name, obj_path) {
+    _registerItem(service, bus_name, obj_path) {
         let id = this._getItemId(bus_name, obj_path);
 
         if (this._items[id]) {
@@ -99,9 +97,9 @@ var StatusNotifierWatcher = new Lang.Class({
                                                             this._itemVanished.bind(this));
 
         this._dbusImpl.emit_property_changed('RegisteredStatusNotifierItems', GLib.Variant.new('as', this.RegisteredStatusNotifierItems));
-    },
+    }
 
-    _ensureItemRegistered: function(service, bus_name, obj_path) {
+    _ensureItemRegistered(service, bus_name, obj_path) {
         let id = this._getItemId(bus_name, obj_path);
 
         if (this._items[id]) {
@@ -111,9 +109,9 @@ var StatusNotifierWatcher = new Lang.Class({
         }
 
         this._registerItem(service, bus_name, obj_path)
-    },
+    }
 
-    _seekStatusNotifierItems: function() {
+    _seekStatusNotifierItems() {
         // Some indicators (*coff*, dropbox, *coff*) do not re-register again
         // when the plugin is enabled/disabled, thus we need to manually look
         // for the objects in the session bus that implements the
@@ -129,9 +127,9 @@ var StatusNotifierWatcher = new Lang.Class({
                 }
             })
         });
-    },
+    }
 
-    RegisterStatusNotifierItemAsync: function(params, invocation) {
+    RegisterStatusNotifierItemAsync(params, invocation) {
         // it would be too easy if all application behaved the same
         // instead, ayatana patched gnome apps to send a path
         // while kde apps send a bus name
@@ -159,50 +157,50 @@ var StatusNotifierWatcher = new Lang.Class({
         this._ensureItemRegistered(service, bus_name, obj_path);
 
         invocation.return_value(null);
-    },
+    }
 
-    _itemVanished: function(proxy, bus_name) {
+    _itemVanished(proxy, bus_name) {
         // FIXME: this is useless if the path name disappears while the bus stays alive (not unheard of)
         for (var i in this._items) {
             if (i.indexOf(bus_name) == 0) {
                 this._remove(i);
             }
         }
-    },
+    }
 
-    _remove: function(id) {
+    _remove(id) {
         this._items[id].destroy();
         delete this._items[id];
         Gio.DBus.session.unwatch_name(this._nameWatcher[id]);
         delete this._nameWatcher[id];
         this._dbusImpl.emit_signal('StatusNotifierItemUnregistered', GLib.Variant.new('(s)', id));
         this._dbusImpl.emit_property_changed('RegisteredStatusNotifierItems', GLib.Variant.new('as', this.RegisteredStatusNotifierItems));
-    },
+    }
 
-    RegisterNotificationHost: function(service) {
+    RegisterNotificationHost(service) {
         throw new Gio.DBusError('org.gnome.Shell.UnsupportedMethod',
                         'Registering additional notification hosts is not supported');
-    },
+    }
 
-    IsNotificationHostRegistered: function() {
+    IsNotificationHostRegistered() {
         return true;
-    },
+    }
 
-    ProtocolVersion: function() {
+    ProtocolVersion() {
         // "The version of the protocol the StatusNotifierWatcher instance implements." [sic]
         // in what syntax?
         return `${Extension.uuid} (KDE; compatible; mostly) GNOME Shell/${ShellConfig.PACKAGE_VERSION}`;
-    },
+    }
 
     get RegisteredStatusNotifierItems() {
         return Object.keys(this._items);
-    },
+    }
 
     get IsStatusNotifierHostRegistered() {
         return true;
-    },
+    }
 
-    destroy: function() {
+    destroy() {
         if (!this._isDestroyed) {
             // this doesn't do any sync operation and doesn't allow us to hook up the event of being finished
             // which results in our unholy debounce hack (see extension.js)
@@ -220,4 +218,4 @@ var StatusNotifierWatcher = new Lang.Class({
             this._isDestroyed = true;
         }
     }
-});
+};

--- a/statusNotifierWatcher.js
+++ b/statusNotifierWatcher.js
@@ -59,7 +59,7 @@ var StatusNotifierWatcher = new Lang.Class({
         this._nameWatcher = { };
 
         this._seekStatusNotifierItems();
-    },
+    }
 
     _acquiredName: function() {
         this._everAcquiredName = true;

--- a/util.js
+++ b/util.js
@@ -137,7 +137,7 @@ const connectSmart3A = function(src, signal, handler) {
     let id = src.connect(signal, handler)
 
     if (src.connect && (!(src instanceof GObject.Object) || GObject.signal_lookup('destroy', src))) {
-        let destroy_id = src.connect('destroy', function() {
+        let destroy_id = src.connect('destroy', () => {
             src.disconnect(id)
             src.disconnect(destroy_id)
         })
@@ -171,7 +171,7 @@ const connectSmart4A = function(src, signal, target, method) {
  * Usage:
  *      Util.connectSmart(srcOb, 'signal', tgtObj, 'handler')
  * or
- *      Util.connectSmart(srcOb, 'signal', function() { ... })
+ *      Util.connectSmart(srcOb, 'signal', () => { ... })
  */
 var connectSmart = function() {
     if (arguments.length == 4)

--- a/util.js
+++ b/util.js
@@ -17,7 +17,6 @@ const Gio = imports.gi.Gio
 const GLib = imports.gi.GLib
 const GObject = imports.gi.GObject
 
-const Lang = imports.lang
 const Signals = imports.signals
 
 var refreshPropertyOnProxy = function(proxy, property_name) {
@@ -183,40 +182,25 @@ var connectSmart = function() {
 /**
  * Helper class for logging stuff
  */
-var Logger = {
-    _log: function(prefix, message) {
+var Logger = class AppIndicators_Logger {
+    static _log(prefix, message) {
         global.log("[AppIndicatorSupport-"+prefix+"] "+message)
-    },
+    }
 
-    debug: function(message) {
+    static debug(message) {
         // CHeck the shell env variable to get what level to use
         Logger._log("DEBUG", message);
-    },
+    }
 
-    warn: function(message) {
+    static warn(message) {
         Logger._log("WARN", message);
-    },
+    }
 
-    error: function(message) {
+    static error(message) {
         Logger._log("ERROR", message);
-    },
+    }
 
-    fatal: function(message) {
+    static fatal(message) {
         Logger._log("FATAL", message);
     }
 };
-
-/**
- * Workaround for https://bugzilla.gnome.org/show_bug.cgi?id=734071
- *
- * Will append the given name with a number to distinguish code loaded later from the last loaded version
- */
-var WORKAROUND_RELOAD_TYPE_REGISTER = function(name) {
-    return 'Gjs_' + name + '__' + global['--appindicator-loaded-count']
-}
-
-// this will only execute once when the extension is loaded
-if (!global['--appindicator-loaded-count'])
-    global['--appindicator-loaded-count'] = 1
-else
-    global['--appindicator-loaded-count']++


### PR DESCRIPTION
As per upstream changes [1], Lang.Class'es aren't supported anymore to extend
GNOME Shell objects, making dash-to-dock not to work anymore.

Keeping compatibility with older versions isn't feasible with a reasonable
quantiy of work, so better to move everything to the new syntax (supported
since GNOME Shell 3.30)

[1] https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/361