### PR TITLE
FIX#107: Indicator stops working after screen lock

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -47,8 +47,8 @@ function init() {
 // monitor the bus manually to find out when the name vanished so we can reclaim it again.
 function maybe_enable_after_name_available() {
     // by the time we get called whe might not be enabled
-    if (isEnabled && !watchDog.isPresent && statusNotifierWatcher === null)
-        statusNotifierWatcher = new StatusNotifierWatcher.StatusNotifierWatcher();
+    if (isEnabled && (!watchDog.nameAcquired || !watchDog.isPresent) && statusNotifierWatcher === null)
+        statusNotifierWatcher = new StatusNotifierWatcher.StatusNotifierWatcher(watchDog);
 }
 
 function enable() {
@@ -75,9 +75,15 @@ var NameWatchdog = class AppIndicators_NameWatchdog {
 
         // will be set in the handlers which are guaranteed to be called at least once
         this.isPresent = false;
+        // Assume the name was acquired...we'll be told otherwise if necessary
+        this.nameAcquired = true;
 
         this._watcher_id = Gio.DBus.session.watch_name("org.kde.StatusNotifierWatcher", 0,
             this._appeared_handler.bind(this), this._vanished_handler.bind(this));
+    }
+
+    setNameAcquired(acquired) {
+        this.nameAcquired = acquired;
     }
 
     destroy() {

--- a/statusNotifierWatcher.js
+++ b/statusNotifierWatcher.js
@@ -44,7 +44,8 @@ const DEFAULT_ITEM_OBJECT_PATH = '/StatusNotifierItem';
  */
 var StatusNotifierWatcher = class AppIndicators_StatusNotifierWatcher {
 
-    constructor() {
+    constructor(watchDog) {
+        this.watchDog = watchDog;
         this._dbusImpl = Gio.DBusExportedObject.wrapJSObject(Interfaces.StatusNotifierWatcher, this);
         this._dbusImpl.export(Gio.DBus.session, WATCHER_OBJECT);
         this._cancellable = new Gio.Cancellable;
@@ -61,6 +62,7 @@ var StatusNotifierWatcher = class AppIndicators_StatusNotifierWatcher {
 
     _acquiredName() {
         this._everAcquiredName = true;
+        if (this.watchDog !== null) this.watchDog.setNameAcquired(true);
     }
 
     _lostName() {
@@ -68,6 +70,7 @@ var StatusNotifierWatcher = class AppIndicators_StatusNotifierWatcher {
             Util.Logger.debug('Lost name' + WATCHER_BUS_NAME);
         else
             Util.Logger.warn('Failed to acquire ' + WATCHER_BUS_NAME);
+        if (this.watchDog !== null) this.watchDog.setNameAcquired(false);
     }
 
 


### PR DESCRIPTION
Added code to handle the case when the name org.kde.StatusNotifierWatcher can't be owned (for whatever reason), and thus the indicators disappear when the lock screen is engaged (manually or otherwise).

This is by no means a final approach, and it may revive some of the side-effects that gave birth to the watchDog object, but I think it's a start.