### PR TITLE
appIndicator: Remove warning on missing overlay icon

### DIFF
--- a/appIndicator.js
+++ b/appIndicator.js
@@ -534,11 +534,6 @@ class AppIndicators_IconActor extends Shell.Stack {
         if (!newIcon && pixmap)
             newIcon = this._createIconFromPixmap(iconSize, pixmap)
 
-        if (!newIcon) {
-            Util.Logger.fatal("unable to update overlay icon");
-            return;
-        }
-
         this._overlayIcon.set_child(newIcon)
     }
 


### PR DESCRIPTION
This was wrongly added in cb1abf5955. The overlay icon is not mandatory
and many applications do not set one, so lets not spam the log.