### PR TITLE
Readme - gnome-shell-extension-tool is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Alternatively, you can check out a version from git and symlink
 
 ```
 ln -s $PWD ~/.local/share/gnome-shell/extensions/appindicatorsupport@rgcjonas.gmail.com
-gnome-shell-extension-tool -e appindicatorsupport@rgcjonas.gmail.com
+gnome-extensions enable appindicatorsupport@rgcjonas.gmail.com
 ```
 
 You may need to restart GNOME Shell (<kbd>Alt</kbd>+<kbd>F2</kbd>, <kbd>r</kbd>, <kbd>⏎</kbd>)


### PR DESCRIPTION
gnome-shell-extension-tool is deprecated (errors out on ubuntu 19.10 when trying to use it), use gnome-extensions instead