### PR TITLE
appIndicator: Fix runtime error when icon can not be loaded

### DIFF
--- a/appIndicator.js
+++ b/appIndicator.js
@@ -405,7 +405,7 @@ class AppIndicators_IconActor extends Shell.Stack {
                                                   Gtk.IconLookupFlags.GENERIC_FALLBACK);
                 // no icon? that's bad!
                 if (iconInfo === null) {
-                    Util.Logger.fatal("unable to lookup icon for " + name);
+                    Util.Logger.critical("unable to lookup icon for " + name);
                 } else { // we have an icon
                     // the icon size may not match the requested size, especially with custom themes
                     if (iconInfo.get_base_size() < size) {


### PR DESCRIPTION
**[why]**
With commit
  bac3f1c0 appIndicator: Support fixed-size icons

a bug has been introduced, that is triggered if an icon can not be
loaded:

gnome-shell[17071]: JS ERROR: TypeError: Util.Logger.fatal is not a function

**[how]**
Our util.js has indeed no fatal(), but only these:
```
    debug(message)
    warn(message)
    error(message)
    critical(message)
```
So I reckon ``critical()`` is what has been meant.