### PR TITLE
Use correct logging method

### DIFF
--- a/appIndicator.js
+++ b/appIndicator.js
@@ -405,7 +405,7 @@ class AppIndicators_IconActor extends Shell.Stack {
                                                   Gtk.IconLookupFlags.GENERIC_FALLBACK);
                 // no icon? that's bad!
                 if (iconInfo === null) {
-                    Util.Logger.fatal("unable to lookup icon for " + name);
+                    Util.Logger.debug("unable to lookup icon for " + name);
                 } else { // we have an icon
                     // the icon size may not match the requested size, especially with custom themes
                     if (iconInfo.get_base_size() < size) {


### PR DESCRIPTION
Fixes an issue introduced with 2af8284493c4631b5584da4a976d1e8534cba9b8
where suddenly errors like these appeard in my systemd log:

```
gnome-shell[5070]: JS ERROR: Exception in callback for signal: icon: TypeError: Util.Logger.fatal is not a function
_getIconInfo@/home/takuto/.local/share/gnome-shell/extensions/appindicatorsupport@rgcjonas.gmail.com/appIndicator.js:408:21
_cacheOrCreateIconByName@/home/takuto/.local/share/gnome-shell/extensions/appindicatorsupport@rgcjonas.gmail.com/appIndicator.js:334:27
_updateIcon@/home/takuto/.local/share/gnome-shell/extensions/appindicatorsupport@rgcjonas.gmail.com/appIndicator.js:513:27
_emit@resource:///org/gnome/gjs/modules/signals.js:135:27
_onPropertiesChanged/<@/home/takuto/.local/share/gnome-shell/extensions/appindicatorsupport@rgcjonas.gmail.com/appIndicator.js:214:17
_onPropertiesChanged@/home/takuto/.local/share/gnome-shell/extensions/appindicatorsupport@rgcjonas.gmail.com/appIndicator.js:208:9
refreshPropertyOnProxy/<@/home/takuto/.local/share/gnome-shell/extensions/appindicatorsupport@rgcjonas.gmail.com/util.js:42:37
```

I also changed the log level to debug because this is not critical and only noisy
logging IMHO. Critical / fatal errors should lead to program
termination which is not the case here.