### PR TITLE
feature: Remove unneeded padding

### DIFF
--- a/appIndicator.js
+++ b/appIndicator.js
@@ -291,7 +291,6 @@ class AppIndicators_IconActor extends St.Icon {
     _init(indicator, icon_size) {
         super._init({
             reactive: true,
-            style_class: 'system-status-icon',
             fallback_icon_name: 'image-loading-symbolic',
         });
 

--- a/appIndicator.js
+++ b/appIndicator.js
@@ -291,11 +291,13 @@ class AppIndicators_IconActor extends St.Icon {
     _init(indicator, icon_size) {
         super._init({
             reactive: true,
+            style_class: 'system-status-icon',
             fallback_icon_name: 'image-loading-symbolic',
         });
 
         this.name = this.constructor.name;
         this.add_style_class_name('appindicator-icon');
+        this.set_style('padding:0');
 
         let themeContext = St.ThemeContext.get_for_stage(global.stage);
         this.height = icon_size * themeContext.scale_factor;


### PR DESCRIPTION
**[why]**
The spacing between icons shown by us seems a bit too wide.
A lot of people would rather have a smaller distance between the icons.

**[how]**
Top bar buttons have a given padding. Additionally to that we pad the
icons a bit more. That padding can be removed, without violating the design
goals imposed by the top bar (i.e. menu button padding).

This makes the visual appearance a bit more pleasing. And still
conforming.

I'm sure people will want to further decrease the distance, but that
will violate the required button padding. A composite button would have
to be used then instead (like the aggregate menu does).