### PR TITLE
Wait until the desktop ends starting up

### DIFF
--- a/appIndicator.js
+++ b/appIndicator.js
@@ -403,6 +403,13 @@ class AppIndicators_IconActor extends St.Icon {
     }
 
     _createIconByName(path, callback) {
+        if (!path) {
+            GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => {
+                callback(null);
+                return false;
+            });
+            return;
+        }
         GdkPixbuf.Pixbuf.get_file_info_async(path, this._cancellable, (_p, res) => {
             try {
                 let [format, width, height] = GdkPixbuf.Pixbuf.get_file_info_finish(res);


### PR DESCRIPTION
Gnome Shell enables the extensions before the desktop itself is ready to accept widgets. This can result in errors. In the case of appindicator, it results in applications that are launched during startup not showing an indicator because, when the extension tries to add the icon to the Gnome Shell interface, it still isn't ready for that, thus failing. But other applications, launched after the Shell has completed the startup process, will work fine.

This patch fixes this by checking in the `enable()` method if Gnome Shell is still starting up, in which case it waits until the `startup-complete` signal is triggered before continuing.

Fix #235