### PR TITLE
Fix Flatpak Icon Bug 

### DIFF
--- a/appIndicator.js
+++ b/appIndicator.js
@@ -366,6 +366,11 @@ class AppIndicators_IconActor extends St.Icon {
 
         this._loadingIcons.add(id);
         let path = this._getIconInfo(iconName, themePath, iconSize, scale_factor);
+        if(path == null) {
+            this._loadingIcons.delete(id);
+            callback(null);
+            return;
+        }
         this._createIconByName(path, (gicon) => {
             this._loadingIcons.delete(id);
             if (gicon) {


### PR DESCRIPTION
Sometimes sandboxed applications don't export their tray icons, so a three-dots icon is shown (see #179, the same happens with some other flatpak tray icons). When an icon is not found we want to use the pixmap provided by the application instead.