### PR TITLE
kstatusnotifierwatcher: Implement ProtocolVersion property

### DIFF
--- a/interfaces-xml/StatusNotifierWatcher.xml
+++ b/interfaces-xml/StatusNotifierWatcher.xml
@@ -19,4 +19,5 @@
         <arg type="s" direction="out" />
     </signal>
     <property name="IsStatusNotifierHostRegistered" type="b" access="read" />
+    <property name="ProtocolVersion" type="i" access="read" />
 </interface>

--- a/statusNotifierWatcher.js
+++ b/statusNotifierWatcher.js
@@ -215,6 +215,10 @@ var StatusNotifierWatcher = class AppIndicators_StatusNotifierWatcher {
         return true;
     }
 
+    get ProtocolVersion() {
+        return 0;
+    }
+
     destroy() {
         if (!this._isDestroyed) {
             // this doesn't do any sync operation and doesn't allow us to hook up the event of being finished


### PR DESCRIPTION
The KNotifications implementation of KStatusNotifierItem expects an Int32 property called `ProtocolVersion` to exist in `org.kde.StatusNotifierWatcher`.
If it doesn't exist, it tries to fall back to a legacy tray icon, and may cause other issues, such as https://github.com/ckb-next/ckb-next/issues/633 .

This behaviour can be seen here.
https://github.com/KDE/knotifications/blob/311cd94ab32b9a916cb86012bca669599878239a/src/kstatusnotifieritem.cpp#L880-L894

The expected protocol version is 0.
https://github.com/KDE/knotifications/blob/311cd94ab32b9a916cb86012bca669599878239a/src/kstatusnotifieritem.cpp#L786

This commit implements the property in the extension.