### PR TITLE
Fix qt based tray icons not appearing on startup

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -14,11 +14,7 @@
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 const Gio = imports.gi.Gio;
-const GLib = imports.gi.GLib;
-const Gtk = imports.gi.Gtk;
 const Gdk = imports.gi.Gdk;
-const Main = imports.ui.main;
-const Mainloop = imports.mainloop;
 
 const Extension = imports.misc.extensionUtils.getCurrentExtension()
 
@@ -28,10 +24,6 @@ const Util = Extension.imports.util
 let statusNotifierWatcher = null;
 let isEnabled = false;
 let watchDog = null;
-let startupPreparedId = 0;
-let waitForThemeId = 0;
-let startupComplete = false;
-let displayAvailable = false;
 
 function init() {
     watchDog = new NameWatchdog();
@@ -59,36 +51,9 @@ function maybe_enable_after_name_available() {
         statusNotifierWatcher = new StatusNotifierWatcher.StatusNotifierWatcher(watchDog);
 }
 
-function inner_enable() {
-    if (startupComplete && displayAvailable) {
-        isEnabled = true;
-        maybe_enable_after_name_available();
-    }
-}
-
 function enable() {
-    // If the desktop is still starting up, we must wait until it is ready
-    if (Main.layoutManager._startingUp) {
-        startupPreparedId = Main.layoutManager.connect('startup-complete', () => {
-            Main.layoutManager.disconnect(startupPreparedId);
-            startupComplete = true;
-            inner_enable();
-        });
-    } else {
-        startupComplete = true;
-    }
-
-    // Ensure that the default Gdk Screen is available
-    if (Gtk.IconTheme.get_default() == null) {
-        waitForThemeId = Gdk.DisplayManager.get().connect('display-opened', () => {
-            Gdk.DisplayManager.get().disconnect(waitForThemeId);
-            displayAvailable = true;
-            inner_enable();
-        });
-    } else {
-        displayAvailable = true;
-    }
-    inner_enable();
+    isEnabled = true;
+    maybe_enable_after_name_available();
 }
 
 function disable() {

--- a/statusNotifierWatcher.js
+++ b/statusNotifierWatcher.js
@@ -16,11 +16,6 @@
 
 const Gio = imports.gi.Gio
 const GLib = imports.gi.GLib
-const Gtk = imports.gi.Gtk
-
-const Mainloop = imports.mainloop
-const ShellConfig = imports.misc.config
-const Signals = imports.signals
 
 const Extension = imports.misc.extensionUtils.getCurrentExtension()
 
@@ -34,7 +29,6 @@ const Util = Extension.imports.util
 const KDE_PREFIX = 'org.kde';
 
 const WATCHER_BUS_NAME = KDE_PREFIX + '.StatusNotifierWatcher';
-const WATCHER_INTERFACE = WATCHER_BUS_NAME;
 const WATCHER_OBJECT = '/StatusNotifierWatcher';
 
 const DEFAULT_ITEM_OBJECT_PATH = '/StatusNotifierItem';
@@ -59,6 +53,7 @@ var StatusNotifierWatcher = class AppIndicators_StatusNotifierWatcher {
         this._items = new Map();
         this._nameWatcher = new Map();
         this._serviceWatcher = new Map();
+        this._startUpCompletionHelper = new Util.StartUpCompletionHelper();
 
         this._seekStatusNotifierItems();
     }
@@ -92,10 +87,17 @@ var StatusNotifierWatcher = class AppIndicators_StatusNotifierWatcher {
         Util.Logger.debug(`Registering StatusNotifierItem ${id}`);
 
         let indicator = new AppIndicator.AppIndicator(bus_name, obj_path);
-        let visual = new IndicatorStatusIcon.IndicatorStatusIcon(indicator);
-        indicator.connect('destroy', () => visual.destroy());
-
         this._items.set(id, indicator);
+
+        // if the desktop is not ready delay the icon creation
+        this._startUpCompletionHelper.whenStartUpComplete(() => {
+            // check that the indicator has not been removed while we were waiting for the startup completion
+            let indicatorItem = this._items.get(id);
+            if (indicatorItem != null) {
+                let visual = new IndicatorStatusIcon.IndicatorStatusIcon(indicatorItem);
+                indicator.connect('destroy', () => visual.destroy());
+            }
+        })
 
         this._dbusImpl.emit_signal('StatusNotifierItemRegistered', GLib.Variant.new('(s)', service));
         this._nameWatcher.set(id, Gio.DBus.session.watch_name(bus_name,


### PR DESCRIPTION
The changes from #231 are delaying the registration of the StatusNotifierWatcher by ~2 seconds.  
A lot of applications unfortunately do not wait for the dbus name to appear correctly.   

The qt implementation with the QSystemTrayIcon, which is for example used in the Nextcloud app does not work correctly. 
If during application startup it does not detect a StatusNotifierWatcher it does not wait for it show up.  

The example project at https://doc.qt.io/qt-5/qtwidgets-desktop-systray-example.html has the same issue with the icon not appearing if launched on system start. (I removed the early isSystemTrayAvailable check, as nextcloud does not check for this either.)

It can also be reproduced by disabling this extension first and then launching the application.  
Enabling the extension later will not trigger the indicator to show up. 
It however works correctly if the extension is enabled during application start and then switched off and on again.

Fixes #250 