### PR TITLE
Add support for GNOME 40

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,9 @@
         "3.33",
         "3.34",
         "3.36",
-        "3.38"
+        "3.38",
+        "40.beta",
+        "40"
     ],
     "uuid": "appindicatorsupport@rgcjonas.gmail.com",
     "name": "KStatusNotifierItem/AppIndicator Support",


### PR DESCRIPTION
This extension supports GNOME 40 without any change, please just mark it as supported in the metadata.json to be able to install it.