### PR TITLE
feature: Add topicons-plus extension logic to AppIndicator extension

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -19,6 +19,7 @@
 const Extension = imports.misc.extensionUtils.getCurrentExtension();
 
 const StatusNotifierWatcher = Extension.imports.statusNotifierWatcher;
+const TopIcons = Extension.imports.topicons;
 const Util = Extension.imports.util;
 
 let statusNotifierWatcher = null;
@@ -56,10 +57,12 @@ function maybeEnableAfterNameAvailable() {
 function enable() {
     isEnabled = true;
     maybeEnableAfterNameAvailable();
+    TopIcons.initTopIcons();
 }
 
 function disable() {
     isEnabled = false;
+    TopIcons.finTopIcons();
     if (statusNotifierWatcher !== null) {
         statusNotifierWatcher.destroy();
         statusNotifierWatcher = null;

--- a/indicatorStatusIcon.js
+++ b/indicatorStatusIcon.js
@@ -14,7 +14,7 @@
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-/* exported IndicatorStatusIcon */
+/* exported IndicatorStatusIcon, IndicatorStatusTopIcon */
 
 const Clutter = imports.gi.Clutter;
 const GObject = imports.gi.GObject;
@@ -30,6 +30,8 @@ const Extension = ExtensionUtils.getCurrentExtension();
 const AppIndicator = Extension.imports.appIndicator;
 const DBusMenu = Extension.imports.dbusMenu;
 const Util = Extension.imports.util;
+
+let legacyTrayNumber = 0;
 
 /*
  * IndicatorStatusIcon implements an icon in the system status area
@@ -149,3 +151,24 @@ class AppIndicatorsIndicatorStatusIcon extends PanelMenu.Button {
         return Clutter.EVENT_PROPAGATE;
     }
 });
+
+var IndicatorStatusTopIcon = GObject.registerClass(
+    class AppIndicatorsIndicatorStatusTopIcon extends PanelMenu.Button {
+        _init(icon) {
+            this._uniqueId = `legacyUniqueId${String(legacyTrayNumber++)}`;
+
+            super._init(0.5, this._uniqueId);
+            this._iconBox = icon;
+            this._box = new St.BoxLayout({ style_class: 'panel-status-indicators-box' });
+            this._box.add_style_class_name('appindicator-box');
+            this.add_child(this._box);
+
+            this._box.add_child(this._iconBox);
+
+            Main.panel.addToStatusArea(`appindicator-${this._uniqueId}`, this, 1, 'right');
+        }
+
+        getIcon() {
+            return this._iconBox;
+        }
+    });

--- a/topicons.js
+++ b/topicons.js
@@ -1,0 +1,148 @@
+// This file is part of the AppIndicator/KStatusNotifierItem GNOME Shell extension
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+/* exported initTopIcons, finTopIcons */
+
+const Shell = imports.gi.Shell;
+const Main = imports.ui.main;
+const System = imports.system;
+
+const ExtensionUtils = imports.misc.extensionUtils;
+
+const Me = ExtensionUtils.getCurrentExtension();
+const IndicatorStatusIcon = Me.imports.indicatorStatusIcon;
+
+var tray = null;
+let trayAddedId = 0;
+let trayRemovedId = 0;
+let icons = [];
+
+function initTopIcons() {
+    tray = Main.legacyTray;
+    if (tray)
+        moveToTop();
+    else
+        createTray();
+}
+
+function finTopIcons() {
+    if (Main.legacyTray)
+        moveToTray();
+    else
+        destroyTray();
+}
+
+function createTray() {
+    tray = new Shell.TrayManager();
+    tray.connect('tray-icon-added', onTrayIconAdded);
+    tray.connect('tray-icon-removed', onTrayIconRemoved);
+
+    tray.manage_screen(Main.panel);
+}
+
+function onTrayIconAdded(o, icon, role, unusedDelay = 1000) {
+    const topIcon = new IndicatorStatusIcon.IndicatorStatusTopIcon(icon);
+
+    icon.connect('destroy', () => {
+        icon.clear_effects();
+        topIcon.destroy();
+    });
+
+    icon.connect('button-release-event', (actor, event) => {
+        icon.click(event);
+    });
+
+    icon.reactive = true;
+    icons.push(topIcon);
+}
+
+function onTrayIconRemoved(o, icon) {
+    let index = -1;
+    for (let i = 0; i < icons.length; i++) {
+        if (icons[i].getIcon() === icon)
+            index = i;
+    }
+
+    if (index === -1)
+        return;
+
+    icon.destroy();
+    icons.splice(index, 1);
+}
+
+function destroyTray() {
+    for (let i = 0; i < icons.length; i++)
+        icons[i].destroy();
+
+    icons = [];
+
+    tray = null;
+    System.gc(); // force finalizing tray to unmanage screen
+}
+
+function moveToTop() {
+
+    // Replace signal handlers
+    if (tray._trayIconAddedId)
+        tray._trayManager.disconnect(tray._trayIconAddedId);
+    if (tray._trayIconRemovedId)
+        tray._trayManager.disconnect(tray._trayIconRemovedId);
+
+    trayAddedId = tray._trayManager.connect('tray-icon-added', onTrayIconAdded);
+    trayRemovedId = tray._trayManager.connect('tray-icon-removed', onTrayIconRemoved);
+
+    // Move each tray icon to the top
+    let length = tray._iconBox.get_n_children();
+    for (let i = 0; i < length; i++) {
+        let button = tray._iconBox.get_child_at_index(0);
+        let icon = button.child;
+        button.remove_actor(icon);
+        button.destroy();
+        // Icon already loaded, no need to delay insertion
+        onTrayIconAdded(this, icon, '', 0);
+    }
+
+}
+
+function moveToTray() {
+
+    // Replace signal handlers
+    if (trayAddedId) {
+        tray._trayManager.disconnect(trayAddedId);
+        trayAddedId = 0;
+    }
+
+    if (trayRemovedId) {
+        tray._trayManager.disconnect(trayRemovedId);
+        trayRemovedId = 0;
+    }
+
+    tray._trayIconAddedId = tray._trayManager.connect(
+        'tray-icon-added', tray._onTrayIconAdded);
+    tray._trayIconRemovedId = tray._trayManager.connect(
+        'tray-icon-removed', tray._onTrayIconRemoved);
+
+    // Clean and move each icon back to the Legacy Tray;
+    for (let i = 0; i < icons.length; i++) {
+        let topIcon = icons[i];
+        let icon = icons.getIcon();
+        tray._onTrayIconAdded(tray, icon);
+        topIcon.destroy();
+    }
+
+    // Clean containers
+    icons = [];
+}


### PR DESCRIPTION
To handle legacy tray, merge topicons-plus extension logic with appindicator extension. Create topicons.js file and connect with original appindicator code.