### PR TITLE
Add support for GNOME 41

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,8 @@
         "3.34",
         "3.36",
         "3.38",
-        "40"
+        "40",
+        "41"
     ],
     "gettext-domain": "AppIndicatorExtension",
     "settings-schema": "org.gnome.shell.extensions.appindicator",


### PR DESCRIPTION
This is a trivial change. Tested on Fedora 35 beta.

Fixes https://github.com/ubuntu/gnome-shell-extension-appindicator/issues/307