### PR TITLE
Mark extension as compatible with GNOME 42

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,8 @@
         "3.36",
         "3.38",
         "40",
-        "41"
+        "41",
+	"42"
     ],
     "gettext-domain": "AppIndicatorExtension",
     "settings-schema": "org.gnome.shell.extensions.appindicator",


### PR DESCRIPTION
Tested on Fedora 36 with GNOME 42 beta from https://bodhi.fedoraproject.org/updates/FEDORA-2022-62ea707376

Works with Nextcloud Desktop and JetBrains Toolbox:
![Screenshot from 2022-02-22 19-47-41](https://user-images.githubusercontent.com/85603/155258755-194c4861-4fa0-42d3-bc0b-1d930d12bffd.png)

Signed-off-by: Michel Alexandre Salim <salimma@fedoraproject.org>