### PR TITLE
List shell version 43 in metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,8 @@
         "3.38",
         "40",
         "41",
-        "42"
+        "42",
+        "43"
     ],
     "gettext-domain": "AppIndicatorExtension",
     "settings-schema": "org.gnome.shell.extensions.appindicator",


### PR DESCRIPTION
Works without a hitch in GNOME 43.alpha. No errors nor warnings reported in logs.

AppIndicator menu from [CLight GUI](https://github.com/nullobsi/clight-gui) shown in screenshot below as example of it working correctly.

Using [FCGU](https://gitlab.com/fabiscafe/gnome-unstable) repo and [AUR](https://wiki.archlinux.org/title/Arch_User_Repository) package [gnome-shell-extension-appindicator-gnome43](https://aur.archlinux.org/packages/gnome-shell-extension-appindicator-gnome43) to test.

![Schermafdruk van 2022-07-14 16-17-37](https://user-images.githubusercontent.com/981494/179004681-f1a0e7dd-3e8d-4e40-a528-8f09fb7d70c4.png)

![Schermafdruk van 2022-07-14 16-20-04](https://user-images.githubusercontent.com/981494/179005235-0b64bfe0-3f81-4a9b-9851-77d4af7ae66f.png)
