### PR TITLE
indicatorStatusIcon: fix status icon location

### DIFF
--- a/indicatorStatusIcon.js
+++ b/indicatorStatusIcon.js
@@ -79,7 +79,7 @@ class AppIndicatorsIndicatorBaseStatusIcon extends PanelMenu.Button {
 
         const indicatorId = `appindicator-${this.uniqueId}`;
         Main.panel.statusArea[indicatorId] = null;
-        Main.panel.addToStatusArea(indicatorId, this, 1,
+        Main.panel.addToStatusArea(indicatorId, this, 0,
             SettingsManager.getDefaultGSettings().get_string('tray-pos'));
     }
 


### PR DESCRIPTION
Prepend the indicator to the panel box, instead of inserting at the first index.

I think this will fix #209. It does fix https://github.com/fflewddur/tophat/issues/25.