### PR TITLE
Pixmap optimizations

### DIFF
--- a/appIndicator.js
+++ b/appIndicator.js
@@ -595,27 +595,27 @@ var AppIndicator = class AppIndicatorsAppIndicator {
     }
 
     get attentionIcon() {
-        return [
-            this._proxy.AttentionIconName,
-            this._proxy.AttentionIconPixmap,
-            this._proxy.IconThemePath,
-        ];
+        return {
+            theme: this._proxy.IconThemePath,
+            name: this._proxy.AttentionIconName,
+            pixmap: this._proxy.AttentionIconPixmap,
+        };
     }
 
     get icon() {
-        return [
-            this._proxy.IconName,
-            this._proxy.IconPixmap,
-            this._proxy.IconThemePath,
-        ];
+        return {
+            theme: this._proxy.IconThemePath,
+            name: this._proxy.IconName,
+            pixmap: this._proxy.IconPixmap,
+        };
     }
 
     get overlayIcon() {
-        return [
-            this._proxy.OverlayIconName,
-            this._proxy.OverlayIconPixmap,
-            this._proxy.IconThemePath,
-        ];
+        return {
+            theme: this._proxy.IconThemePath,
+            name: this._proxy.OverlayIconName,
+            pixmap: this._proxy.OverlayIconPixmap,
+        };
     }
 
     get hasNameOwner() {
@@ -1301,7 +1301,7 @@ class AppIndicatorsIconActor extends St.Icon {
             break;
         }
 
-        const [name, pixmap, theme] = icon;
+        const { theme, name, pixmap } = icon;
         const commonArgs = [theme, iconType, iconSize];
 
         if (this._customIcons.size) {

--- a/appIndicator.js
+++ b/appIndicator.js
@@ -151,6 +151,12 @@ var AppIndicatorProxy = GObject.registerClass({
         this.emit('destroy');
         this._signalIds.forEach(id => this.disconnect(id));
 
+        const cachedProperties = this.get_cached_property_names();
+        if (cachedProperties) {
+            cachedProperties.forEach(propertyName =>
+                this.set_cached_property(propertyName, null));
+        }
+
         if (this._cancellable)
             this._cancellable.cancel();
 

--- a/appIndicator.js
+++ b/appIndicator.js
@@ -44,24 +44,24 @@ PromiseUtils._promisify(Gio.DBusProxy.prototype, 'init_async', 'init_finish');
 const MAX_UPDATE_FREQUENCY = 100; // In ms
 
 // eslint-disable-next-line no-unused-vars
-const SNICategory = {
+const SNICategory = Object.freeze({
     APPLICATION: 'ApplicationStatus',
     COMMUNICATIONS: 'Communications',
     SYSTEM: 'SystemServices',
     HARDWARE: 'Hardware',
-};
+});
 
-var SNIStatus = {
+var SNIStatus = Object.freeze({
     PASSIVE: 'Passive',
     ACTIVE: 'Active',
     NEEDS_ATTENTION: 'NeedsAttention',
-};
+});
 
-const SNIconType = {
+const SNIconType = Object.freeze({
     NORMAL: 0,
     ATTENTION: 1,
     OVERLAY: 2,
-};
+});
 
 var AppIndicatorProxy = GObject.registerClass({
     Signals: { 'destroy': {} },

--- a/appIndicator.js
+++ b/appIndicator.js
@@ -66,11 +66,11 @@ var AppIndicatorProxy = GObject.registerClass({
     Signals: { 'destroy': {} },
 }, class AppIndicatorProxy extends Gio.DBusProxy {
     static get interfaceInfo() {
-        if (!AppIndicator._interfaceInfo) {
-            AppIndicator._interfaceInfo = Gio.DBusInterfaceInfo.new_for_xml(
+        if (!this._interfaceInfo) {
+            this._interfaceInfo = Gio.DBusInterfaceInfo.new_for_xml(
                 Interfaces.StatusNotifierItem);
         }
-        return AppIndicator._interfaceInfo;
+        return this._interfaceInfo;
     }
 
     static get OPTIONAL_PROPERTIES() {
@@ -83,8 +83,24 @@ var AppIndicatorProxy = GObject.registerClass({
         ];
     }
 
+    static get TUPLE_TYPE() {
+        if (!this._tupleType)
+            this._tupleType = new GLib.VariantType('()');
+
+        return this._tupleType;
+    }
+
+    static get TUPLE_VARIANT_TYPE() {
+        if (!this._tupleVariantType)
+            this._tupleVariantType = new GLib.VariantType('(v)');
+
+        return this._tupleVariantType;
+    }
+
     static destroy() {
-        delete AppIndicator._interfaceInfo;
+        delete this._interfaceInfo;
+        delete this._tupleVariantType;
+        delete this._tupleType;
     }
 
     _init(busName, objectPath) {
@@ -206,7 +222,7 @@ var AppIndicatorProxy = GObject.registerClass({
             return;
         }
 
-        if (property && !params.get_type().equal(GLib.VariantType.new('()'))) {
+        if (!params.get_type().equal(AppIndicatorProxy.TUPLE_TYPE)) {
             // If the property includes arguments, we can just queue the signal emission
             const [value] = params.unpack();
             try {
@@ -270,7 +286,7 @@ var AppIndicatorProxy = GObject.registerClass({
         return this.g_connection.call(this.g_name,
             this.g_object_path, 'org.freedesktop.DBus.Properties', 'Get',
             GLib.Variant.new('(ss)', [this.g_interface_name, propertyName]),
-            GLib.VariantType.new('(v)'), Gio.DBusCallFlags.NONE, -1,
+            AppIndicatorProxy.TUPLE_VARIANT_TYPE, Gio.DBusCallFlags.NONE, -1,
             cancellable);
     }
 

--- a/appIndicator.js
+++ b/appIndicator.js
@@ -195,7 +195,7 @@ var AppIndicatorProxy = GObject.registerClass({
     }
 
     // The Author of the spec didn't like the PropertiesChanged signal, so he invented his own
-    async _refreshProperty(prop) {
+    async _refreshOwnProperties(prop) {
         await Promise.all(
             [prop, `${prop}Name`, `${prop}Pixmap`, `${prop}AccessibleDesc`].filter(p =>
                 this._propertiesList.includes(p)).map(async p => {
@@ -246,7 +246,8 @@ var AppIndicatorProxy = GObject.registerClass({
         try {
             await this._signalsAccumulator;
             const refreshPropertiesPromises =
-                [...this._accumulatedProperties].map(p => this._refreshProperty(p));
+                [...this._accumulatedProperties].map(p =>
+                    this._refreshOwnProperties(p));
             this._accumulatedProperties.clear();
             await Promise.all(refreshPropertiesPromises);
         } catch (e) {

--- a/pixmapsUtils.js
+++ b/pixmapsUtils.js
@@ -1,0 +1,70 @@
+// This file is part of the AppIndicator/KStatusNotifierItem GNOME Shell extension
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+/* exported argbToRgba, getBestPixmap */
+
+function argbToRgba(src) {
+    const dest = new Uint8Array(src.length);
+
+    for (let j = 0; j < src.length; j += 4) {
+        const srcAlpha = src[j];
+
+        dest[j] = src[j + 1]; /* red */
+        dest[j + 1] = src[j + 2]; /* green */
+        dest[j + 2] = src[j + 3]; /* blue */
+        dest[j + 3] = srcAlpha; /* alpha */
+    }
+
+    return dest;
+}
+
+function getBestPixmap(pixmapsVariant, preferredSize) {
+    if (!pixmapsVariant)
+        throw new TypeError('null pixmapsVariant');
+
+    const pixmapsVariantsArray = new Array(pixmapsVariant.n_children());
+    if (!pixmapsVariantsArray.length)
+        throw TypeError('Empty Icon found');
+
+    for (let i = 0; i < pixmapsVariantsArray.length; ++i)
+        pixmapsVariantsArray[i] = pixmapsVariant.get_child_value(i);
+
+    const pixmapsSizedArray = pixmapsVariantsArray.map((pixmapVariant, index) => ({
+        width: pixmapVariant.get_child_value(0).unpack(),
+        height: pixmapVariant.get_child_value(1).unpack(),
+        index,
+    }));
+
+    const sortedIconPixmapArray = pixmapsSizedArray.sort(
+        ({ width: widthA, height: heightA }, { width: widthB, height: heightB }) => {
+            const areaA = widthA * heightA;
+            const areaB = widthB * heightB;
+
+            return areaA - areaB;
+        });
+
+    // we prefer any pixmap that is equal or bigger than our requested size
+    const qualifiedIconPixmapArray = sortedIconPixmapArray.filter(({ width, height }) =>
+        width >= preferredSize && height >= preferredSize);
+
+    const { width, height, index } = qualifiedIconPixmapArray.length > 0
+        ? qualifiedIconPixmapArray[0] : sortedIconPixmapArray.pop();
+
+    const pixmapVariant = pixmapsVariantsArray[index].get_child_value(2);
+    const rowStride = width * 4; // hopefully this is correct
+
+    return { pixmapVariant, width, height, rowStride };
+}


### PR DESCRIPTION
Optimize various cases when pixmap icons are used, so that we can reduce their memory impact and do less operations, avoiding to unpack the variants we don't care about.