### PR TITLE
Use theme-node based icon lookup and colorize symbolic icons

### DIFF
--- a/appIndicator.js
+++ b/appIndicator.js
@@ -1274,6 +1274,7 @@ class AppIndicatorsIconActor extends St.Icon {
             if (iconTheme) {
                 // try to look up the icon in the icon theme
                 iconInfo = iconTheme.lookup_icon_for_scale(name, size, scale,
+                    this._getIconLookupFlags(this.get_theme_node()) |
                     Gtk.IconLookupFlags.GENERIC_FALLBACK);
                 // no icon? that's bad!
                 if (iconInfo === null) {


### PR DESCRIPTION
This applies to all the versions < 44, where we only use GdkPixbuf's (to avoid StCache) to load the images.

Closes: #404 