### PR TITLE
appIndicator: Wait for style change if no stage is set

### DIFF
--- a/appIndicator.js
+++ b/appIndicator.js
@@ -984,11 +984,12 @@ class AppIndicatorsIconActor extends St.Icon {
             if (this.get_stage()) {
                 this._invalidateIcon();
             } else {
-                const id = this.connect('parent-set', () => {
-                    if (this.get_stage()) {
-                        this.disconnect(id);
-                        this._invalidateIcon();
-                    }
+                const waitStyleChange = new PromiseUtils.SignalConnectionPromise(
+                    this, 'style-changed', this._cancellable);
+
+                waitStyleChange.then(() => this._invalidateIcon()).catch(e => {
+                    if (!e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.CANCELLED))
+                        logError(e);
                 });
             }
         }


### PR DESCRIPTION
In case the stage is not set we may not have proper signaling until the actor is mapped, what we care is having a proper style here though so let's wait for that