### PR TITLE
appIndicator Use Clutter to load RGBA Pixmap textures natively

### DIFF
--- a/appIndicator.js
+++ b/appIndicator.js
@@ -1234,8 +1234,8 @@ class AppIndicatorsIconActor extends St.Icon {
             height, scaleFactor, resourceScale);
 
         customImage.set({
-            xAlign: imports.gi.Clutter.ActorAlign.CENTER,
-            yAlign: imports.gi.Clutter.ActorAlign.CENTER,
+            xAlign: Clutter.ActorAlign.CENTER,
+            yAlign: Clutter.ActorAlign.CENTER,
         });
 
         if (customImage.content) {
@@ -1299,7 +1299,7 @@ class AppIndicatorsIconActor extends St.Icon {
                 iconTheme.append_search_path(themePath);
 
                 if (!Meta.is_wayland_compositor() && !St.IconTheme) {
-                    const defaultScreen = imports.gi.Gdk.Screen.get_default();
+                    const defaultScreen = Gdk.Screen.get_default();
                     if (defaultScreen)
                         iconTheme.set_screen(defaultScreen);
                 }

--- a/indicatorStatusIcon.js
+++ b/indicatorStatusIcon.js
@@ -247,10 +247,6 @@ class AppIndicatorsIndicatorStatusIcon extends BaseStatusIcon {
             this._updateStatus();
             this._updateLabel();
         });
-        Util.connectSmart(this.icon, 'requires-custom-image', this, () => {
-            this._setIconActor(new AppIndicator.CustomImageIconActor(
-                indicator, Panel.PANEL_ICON_SIZE));
-        });
         Util.connectSmart(this._indicator, 'accessible-name', this, () =>
             this.set_accessible_name(this._indicator.accessibleName));
         Util.connectSmart(this._indicator, 'destroy', this, () => this.destroy());


### PR DESCRIPTION
Avoid doing the conversion JS, as Clutter can handle this natively.

In case we don't have overlays (and then we don't need to create an emblemed
icon), we can avoid going through reading the texture, but just leave to
clutter the role of painting the ImageContent as it is.

Closes: #295