### PR TITLE
appIndicator: Refactor named icons lookup and loading

### DIFF
--- a/appIndicator.js
+++ b/appIndicator.js
@@ -48,7 +48,7 @@ if (St.IconInfo)
 else
     PromiseUtils._promisify(Gtk.IconInfo.prototype, 'load_symbolic_async', 'load_symbolic_finish');
 
-const MAX_UPDATE_FREQUENCY = 100; // In ms
+const MAX_UPDATE_FREQUENCY = 30; // In ms
 const FALLBACK_ICON_NAME = 'image-loading-symbolic';
 const PIXMAPS_FORMAT = imports.gi.Cogl.PixelFormat.ARGB_8888;
 
@@ -357,8 +357,8 @@ class AppIndicatorProxy extends Util.DBusProxy {
                     addNew: true,
                 });
             }
-            this._propertiesEmitTimeout = new PromiseUtils.TimeoutPromise(16,
-                GLib.PRIORITY_DEFAULT_IDLE, params.cancellable);
+            this._propertiesEmitTimeout = new PromiseUtils.TimeoutPromise(
+                MAX_UPDATE_FREQUENCY * 2, GLib.PRIORITY_DEFAULT_IDLE, params.cancellable);
             await this._propertiesEmitTimeout;
 
             if (Object.keys(this._changedProperties).length) {

--- a/appIndicator.js
+++ b/appIndicator.js
@@ -1167,7 +1167,7 @@ class AppIndicatorsIconActor extends St.Icon {
             } finally {
                 delete this._createIconIdle;
             }
-            return null;
+            return this.gicon;
         } else if (this._createIconIdle) {
             this._createIconIdle.cancel();
             delete this._createIconIdle;

--- a/appIndicator.js
+++ b/appIndicator.js
@@ -248,7 +248,7 @@ class AppIndicatorProxy extends Util.DBusProxy {
             return;
 
         this._signalsAccumulator = new PromiseUtils.TimeoutPromise(
-            GLib.PRIORITY_DEFAULT_IDLE, MAX_UPDATE_FREQUENCY, this._cancellable);
+            MAX_UPDATE_FREQUENCY, GLib.PRIORITY_DEFAULT_IDLE, this._cancellable);
         try {
             await this._signalsAccumulator;
             const refreshPropertiesPromises =

--- a/indicator-test-tool/testTool.js
+++ b/indicator-test-tool/testTool.js
@@ -61,14 +61,14 @@ const ScrollType = {
                 16, Gtk.IconLookupFlags.GENERIC_FALLBACK);
             let iconFile = Gio.File.new_for_path(iconInfo.get_filename());
             let [, extension] = iconFile.get_basename().split('.');
-            let newName = `${iconName}-${Math.floor(Math.random() * 100)}.${extension}`;
+            let newName = `${Math.floor(Math.random() * 100)}${iconName}.${extension}`;
             let newFile = Gio.File.new_for_path(
                 `${GLib.dir_make_tmp('indicator-test-XXXXXX')}/${newName}`);
             temporaryFiles.push(newFile, newFile.get_parent());
             iconFile.copy(newFile, Gio.FileCopyFlags.OVERWRITE, null, null);
 
             indicator.set_icon_theme_path(newFile.get_parent().get_path());
-            indicator.set_icon(newFile.get_basename());
+            indicator.set_icon(newFile.get_basename().split('.').slice(0, -1).join(''));
         };
 
         var menu = new Gtk.Menu();

--- a/indicatorStatusIcon.js
+++ b/indicatorStatusIcon.js
@@ -591,9 +591,11 @@ class AppIndicatorsIndicatorTrayIcon extends BaseStatusIcon {
             iconSize = Panel.PANEL_ICON_SIZE;
 
         this.height = -1;
-        this._icon.set_width(iconSize * scaleFactor);
-        this._icon.set_height(iconSize * scaleFactor);
-        this._icon.set_y_align(Clutter.ActorAlign.CENTER);
-        this._icon.set_x_align(Clutter.ActorAlign.CENTER);
+        this._icon.set({
+            width: iconSize * scaleFactor,
+            height: iconSize * scaleFactor,
+            xAlign: Clutter.ActorAlign.CENTER,
+            yAlign: Clutter.ActorAlign.CENTER,
+        });
     }
 });

--- a/statusNotifierWatcher.js
+++ b/statusNotifierWatcher.js
@@ -279,6 +279,7 @@ var StatusNotifierWatcher = class AppIndicatorsStatusNotifierWatcher {
         DBusMenu.DBusClient.destroy();
         AppIndicator.AppIndicatorProxy.destroy();
         Util.DBusProxy.destroy();
+        Util.destroyDefaultTheme();
 
         this._dbusImpl.run_dispose();
         delete this._dbusImpl;

--- a/util.js
+++ b/util.js
@@ -16,7 +16,7 @@
 
 /* exported CancellableChild, getUniqueBusName, getBusNames,
    introspectBusObject, dbusNodeImplementsInterfaces, waitForStartupCompletion,
-   connectSmart, disconnectSmart, versionCheck, getDefaultTheme,
+   connectSmart, disconnectSmart, versionCheck, getDefaultTheme, destroyDefaultTheme,
    getProcessName, indicatorId, tryCleanupOldIndicators, DBusProxy */
 
 const ByteArray = imports.byteArray;
@@ -260,19 +260,29 @@ function disconnectSmart(...args) {
     throw new TypeError('Unexpected number of arguments');
 }
 
+let _defaultTheme;
 function getDefaultTheme() {
-    if (St.IconTheme)
-        return new St.IconTheme();
+    if (_defaultTheme)
+        return _defaultTheme;
 
-    if (Gdk.Screen && Gdk.Screen.get_default()) {
-        const defaultTheme = Gtk.IconTheme.get_default();
-        if (defaultTheme)
-            return defaultTheme;
+    if (St.IconTheme) {
+        _defaultTheme = new St.IconTheme();
+        return _defaultTheme;
     }
 
-    const defaultTheme = new Gtk.IconTheme();
-    defaultTheme.set_custom_theme(St.Settings.get().gtk_icon_theme);
-    return defaultTheme;
+    if (Gdk.Screen && Gdk.Screen.get_default()) {
+        _defaultTheme = Gtk.IconTheme.get_default();
+        if (_defaultTheme)
+            return _defaultTheme;
+    }
+
+    _defaultTheme = new Gtk.IconTheme();
+    _defaultTheme.set_custom_theme(St.Settings.get().gtk_icon_theme);
+    return _defaultTheme;
+}
+
+function destroyDefaultTheme() {
+    _defaultTheme = null;
 }
 
 // eslint-disable-next-line valid-jsdoc


### PR DESCRIPTION
From main commit:

```
We used to always looking up for the icons ourself, somewhat duplicating
the shell work, it allowed to prevent shell caching of some files, but still
we can remove lots of deprecated code and handle things more smartly given
that texture-caching can be good in case of well-known files.

In short:
 - named-only icons are now loaded through a Gio.ThemedIcon (and so cached)
 - icons with custom theme are searched in provided path and behave just
   like any other icon with full path as explained below.
 - icons with a full icon path (provided by the theme or not) may be loaded
   in different ways:
   * Using a Gio.FileIcon if they are in non-writable areas (so we assume
     that there are only a limited number of them) and they are cashed.
   * using a StTextureCacheSkippingFileIcon in newer gjs versions and so
     basically they're non-cachable Gio.FileIcon's
   * using a GdkPixbuf, potentially loaded via the icon theme (for svgs) in
     older gjs versions, and so that's not cached.
```