### PR TITLE
Remove the Wayland note

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ gnome-extensions enable appindicatorsupport@rgcjonas.gmail.com
 ```
 
 Under X11, you may need to restart GNOME Shell (<kbd>Alt</kbd>+<kbd>F2</kbd>, <kbd>r</kbd>, <kbd>⏎</kbd>)
-after that. Under Wayland you need to logout and login again.
+after that. 
 
 ### Applications dependencies
 


### PR DESCRIPTION
The Wayland GNOME session doesn't need the shell to be restarted at all when extensions are installed; at least on GNOME 44, they work right away.