### PR TITLE
Fix this._watchDog can be undefined

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -80,6 +80,9 @@ export default class DashToDockExtension extends Extension.Extension {
         if (!this._isEnabled || this._statusNotifierWatcher)
             return;
 
+        if (!this._watchDog)
+            return;
+
         if (this._watchDog.nameAcquired && this._watchDog.nameOnBus)
             return;
 


### PR DESCRIPTION
Having the issue sometimes since I installed it, I found that when deactivating and reactivating cause the extension to crash with `this._watchDog is undefined`. Just check if this._watchDog is set before accessing its values