### PR TITLE
Update metadata.json for Gnome 46

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,7 @@
 {
     "shell-version": [
-        "45", "46"
+        "45",
+        "46"
     ],
     "gettext-domain": "AppIndicatorExtension",
     "settings-schema": "org.gnome.shell.extensions.appindicator",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
     "shell-version": [
-        "45"
+        "45", "46"
     ],
     "gettext-domain": "AppIndicatorExtension",
     "settings-schema": "org.gnome.shell.extensions.appindicator",


### PR DESCRIPTION
As of 46.alpha I have found that adding 46 into the shell version allows appindicator to work on Gnome 46 with out any other intervention.