### PR TITLE
Add extra debug info

### DIFF
--- a/appIndicator.js
+++ b/appIndicator.js
@@ -312,7 +312,10 @@ class AppIndicatorProxy extends DBusProxy {
         } catch (e) {
             if (!e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.CANCELLED)) {
                 // the property may not even exist, silently ignore it
-                Util.Logger.debug(`While refreshing property ${propertyName}: ${e}`);
+                Util.Logger.debug(`Error when calling 'Get(${propertyName})' ` +
+                    `in ${this.gName}, ${this.gObjectPath}, ` +
+                    `org.freedesktop.DBus.Properties, ${this.gInterfaceName} ` +
+                    `while refreshing property ${propertyName}: ${e}`);
                 this.set_cached_property(propertyName, null);
                 this._cancellables.delete(propertyName);
                 delete this._changedProperties[propertyName];

--- a/dbusMenu.js
+++ b/dbusMenu.js
@@ -517,6 +517,8 @@ export const DBusClient = GObject.registerClass({
                 ret.is_of_type(new GLib.VariantType('()')))
                 this._requestLayoutUpdate();
         } catch (e) {
+            Util.Logger.debug('Error when calling \'AboutToShow()\' in ' +
+                `${this.gName}, ${this.gObjectPath}, ${this.gInterfaceName}`);
             if (e.matches(Gio.DBusError, Gio.DBusError.UNKNOWN_METHOD) ||
                 e.matches(Gio.DBusError, Gio.DBusError.FAILED)) {
                 this._hasAboutToShow = false;


### PR DESCRIPTION
This patch show extra debug info for DBus; specifically, when some DBus calls fail, it shows the called address, object and interface, to allow to identify the misbehaving application.