### PR TITLE
Fix first click being treated as both a single and double click by deleting vfunc_button_release_event

### DIFF
--- a/indicatorStatusIcon.js
+++ b/indicatorStatusIcon.js
@@ -420,13 +420,6 @@ class IndicatorStatusIcon extends BaseStatusIcon {
         return Clutter.EVENT_PROPAGATE;
     }
 
-    vfunc_button_release_event(event) {
-        if (!this._indicator.supportsActivation)
-            return this._maybeHandleDoubleClick(event);
-
-        return Clutter.EVENT_PROPAGATE;
-    }
-
     vfunc_scroll_event(event) {
         // Since Clutter 1.10, clutter will always send a smooth scrolling event
         // with explicit deltas, no matter what input device is used


### PR DESCRIPTION
Fixes #516

The problem is that both vfunc_button_press_event and vfunc_button_release_event call _maybeHandleDoubleClick the first time around, so a press+release becomes a double click. But the second time, this._indicator.supportsActivation has been set to true instead of undefined, so vfunc_button_release_event doesn't trigger the double click.

The deleted code cannot be useful because...
- if supportsActivation is false, _maybeHandleDoubleClick immediately returns EVENT_PROPAGATE
- if supportsActivation is true, vfunc_button_release_event skips _maybeHandleDoubleClick and returns EVENT_PROPAGATE
- if it's undefined and changes value, we get the aforementioned bug.