### PR TITLE
iconCache: Gio.Icon.equal(), not .equals()

### DIFF
--- a/iconCache.js
+++ b/iconCache.js
@@ -49,7 +49,7 @@ export class IconCache {
         }
 
         const oldIcon = this._cache.get(id);
-        if (!oldIcon || !oldIcon.equals(icon)) {
+        if (!oldIcon || !oldIcon.equal(icon)) {
             Util.Logger.debug(`IconCache: adding ${id}: ${icon}`);
             this._cache.set(id, icon);
         } else {


### PR DESCRIPTION
The comparison function is named `equal()`.
https://docs.gtk.org/gio/method.Icon.equal.html

Fixes this traceback:
```text
Apr 14 17:15:41 gnome-shell[2368055]: 
remmina-icon unable to update icon: TypeError: oldIcon.equals is not a function
Stack trace:
add@file:///.../appindicatorsupport@rgcjonas.gmail.com/iconCache.js:52:34
_cacheOrCreateIconByName@file:///.../appindicatorsupport@rgcjonas.gmail.com/appIndicator.js:1074:37
async*_createIcon@file:///.../appindicatorsupport@rgcjonas.gmail.com/appIndicator.js:1440:38
_createAndSetIcon@file:///.../appindicatorsupport@rgcjonas.gmail.com/appIndicator.js:1400:32
_updateIconByType@file:///.../appindicatorsupport@rgcjonas.gmail.com/appIndicator.js:1392:24
_updateIcon@file:///.../appindicatorsupport@rgcjonas.gmail.com/appIndicator.js:1469:24
_invalidateIcon@file:///.../appindicatorsupport@rgcjonas.gmail.com/appIndicator.js:1524:14
_invalidateIconWhenFullyReady@file:///.../appindicatorsupport@rgcjonas.gmail.com/appIndicator.js:1507:18
async*_init/<@file:///.../appindicatorsupport@rgcjonas.gmail.com/appIndicator.js:915:24
_callHandlers@resource:///org/gnome/gjs/modules/core/_signals.js:130:42
_emit@resource:///org/gnome/gjs/modules/core/_signals.js:119:10
reset@file:///.../appindicatorsupport@rgcjonas.gmail.com/appIndicator.js:698:14
_ensureItemRegistered@file:///.../appindicatorsupport@rgcjonas.gmail.com/statusNotifierWatcher.js:136:18
RegisterStatusNotifierItemAsync@file:///.../appindicatorsupport@rgcjonas.gmail.com/statusNotifierWatcher.js:205:24
_handleMethodCall@resource:///org/gnome/gjs/modules/core/overrides/Gio.js:373:35
_wrapJSObject/<@resource:///org/gnome/gjs/modules/core/overrides/Gio.js:408:34
@resource:///org/gnome/shell/ui/init.js:21:20
```
