### PR TITLE
dbusMenu: Handle missing AboutToShow gracefully

### DIFF
--- a/dbusMenu.js
+++ b/dbusMenu.js
@@ -495,6 +495,9 @@ export const DBusClient = GObject.registerClass({
 
     // we don't need to cache and burst-send that since it will not happen that frequently
     async sendAboutToShow(id) {
+        if (this._hasAboutToShow === false)
+            return;
+
         /* Some indicators (you, dropbox!) don't use the right signature
          * and don't return a boolean, so we need to support both cases */
         try {
@@ -507,6 +510,11 @@ export const DBusClient = GObject.registerClass({
                 ret.is_of_type(new GLib.VariantType('()')))
                 this._requestLayoutUpdate();
         } catch (e) {
+            if (e.matches(Gio.DBusError, Gio.DBusError.UNKNOWN_METHOD) ||
+                e.matches(Gio.DBusError, Gio.DBusError.FAILED)) {
+                this._hasAboutToShow = false;
+                return;
+            }
             if (!e.matches(Gio.IOErrorEnum, Gio.IOErrorEnum.CANCELLED))
                 logError(e);
         }


### PR DESCRIPTION
It's not defined in all the implementations, so in case that we
have not, let's just ignore the error and avoid calling it again
    
 Fixes: #502