### PR TITLE
metadata: Mark compatible with GNOME Shell 47

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,8 @@
 {
     "shell-version": [
         "45",
-        "46"
+        "46",
+        "47"
     ],
     "gettext-domain": "AppIndicatorExtension",
     "settings-schema": "org.gnome.shell.extensions.appindicator",


### PR DESCRIPTION
The extension appears to work for me with GNOME Shell 47 Beta

I did see this in my journal but I don't know if this is a new error:

```
Gio.DBusError: GDBus.Error:org.freedesktop.DBus.Error.Failed: error occurred in Get

Stack trace:
  _promisify/proto[asyncFunc]/</<@resource:///org/gnome/gjs/modules/core/overrides/Gio.js:453:45
  @resource:///org/gnome/shell/ui/init.js:21:20
  ### Promise created here: ###
  getProperty@file:///usr/share/gnome-shell/extensions/ubuntu-appindicators@ubuntu.com/dbusProxy.js:89:33
  refreshProperty@file:///usr/share/gnome-shell/extensions/ubuntu-appindicators@ubuntu.com/appIndicator.js:306:48
  _refreshOwnProperties/<@file:///usr/share/gnome-shell/extensions/ubuntu-appindicators@ubuntu.com/appIndicator.js:192:32
  _refreshOwnProperties@file:///usr/share/gnome-shell/extensions/ubuntu-appindicators@ubuntu.com/appIndicator.js:190:51
  _onSignalAsync/refreshPropertiesPromises<@file:///usr/share/gnome-shell/extensions/ubuntu-appindicators@ubuntu.com/appIndicator.js:246:26
  _onSignalAsync@file:///usr/share/gnome-shell/extensions/ubuntu-appindicators@ubuntu.com/appIndicator.js:245:50
  async*_onSignal@file:///usr/share/gnome-shell/extensions/ubuntu-appindicators@ubuntu.com/appIndicator.js:204:14
  _init/<@file:///usr/share/gnome-shell/extensions/ubuntu-appindicators@ubuntu.com/dbusProxy.js:40:43
  @resource:///org/gnome/shell/ui/init.js:21:20
```

Closes: #536