### PR TITLE
trayIconsManager: Use panel-matching background color for tray manager

### DIFF
--- a/trayIconsManager.js
+++ b/trayIconsManager.js
@@ -89,14 +89,8 @@ export class TrayIconsManager extends Signals.EventEmitter {
             return;
 
         IndicatorStatusIcon.getTrayIcons().forEach(i => i.destroy());
-        if (this._tray.unmanage_screen) {
-            this._tray.unmanage_screen();
-            this._tray = null;
-        } else {
-            // FIXME: This is very ugly, but it's needed by old shell versions
-            this._tray = null;
-            imports.system.gc(); // force finalizing tray to unmanage screen
-        }
+        this._tray.unmanage_screen();
+        this._tray = null;
     }
 
     onTrayIconAdded(_tray, icon) {


### PR DESCRIPTION
Tray icons in the shell may not use RGBA visuals, so in such case we
need to set the proper background color or we'll just show them with
black background and this is an issue with light or custom themes

Fixes: #446