### PR TITLE
Never log failure to retrieve an optional property

### DIFF
--- a/appIndicator.js
+++ b/appIndicator.js
@@ -194,7 +194,7 @@ class AppIndicatorProxy extends DBusProxy {
                     });
                 } catch (e) {
                     if (!AppIndicatorProxy.OPTIONAL_PROPERTIES.includes(p) ||
-                        !e.matches(Gio.DBusError, Gio.DBusError.UNKNOWN_PROPERTY))
+                        !(e instanceof Gio.DBusError))
                         logError(e);
                 }
             }));


### PR DESCRIPTION
Chromium and Electron apps do not implement the IconAccessibleDesc property and reply to the Get() method with a generic
  org.freedesktop.DBus.Error.Failed

Rather than adding the generic error to the list of allowed errors, remove the filtering on the error type altogether.

Fixes: #534
LP: #2064698