### PR TITLE
update and open menu if there's no entries

### DIFF
--- a/indicatorStatusIcon.js
+++ b/indicatorStatusIcon.js
@@ -403,18 +403,31 @@ class IndicatorStatusIcon extends BaseStatusIcon {
         }
 
         if (event.get_button() === Clutter.BUTTON_SECONDARY) {
-            this.menu.toggle();
+            if (this.menu.numMenuItems) {
+                this.menu.toggle();
+            } else {
+                // update menu if there's no entries
+                this._updateMenu();
+                // wait for menu update
+                this._waitForDoubleClick().catch(logError);
+            }
             return Clutter.EVENT_PROPAGATE;
         }
 
         const doubleClickHandled = this._maybeHandleDoubleClick(event);
         if (doubleClickHandled === Clutter.EVENT_PROPAGATE &&
-            event.get_button() === Clutter.BUTTON_PRIMARY &&
-            this.menu.numMenuItems) {
-            if (this._indicator.supportsActivation !== false)
+            event.get_button() === Clutter.BUTTON_PRIMARY) {
+            if (this.menu.numMenuItems) {
+                if (this._indicator.supportsActivation !== false)
+                    this._waitForDoubleClick().catch(logError);
+                else
+                    this.menu.toggle();
+            } else {
+                // update menu if there's no entries
+                this._updateMenu();
+                // wait for double click or menu update
                 this._waitForDoubleClick().catch(logError);
-            else
-                this.menu.toggle();
+            }
         }
 
         return Clutter.EVENT_PROPAGATE;


### PR DESCRIPTION
This PR (partially) fixes #494.

_QQ_ is an _IM_ app who provides no menu entries before user logged in, and updates it when logged in. But it probably does not emit a `LayoutUpdated` signal before updating menu so its tray icon menu can never open until _appindicator_ restarts (by disabling the extension or ending gnome session). Here we try updating entries before opening an empty menu. Only primary click and secondary click will trigger an update.

Wondering if there are better solutions...