### PR TITLE
Change default icon size to 20 so they aren't defacto invisible

### DIFF
--- a/schemas/org.gnome.shell.extensions.appindicator.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.appindicator.gschema.xml
@@ -21,7 +21,7 @@
       <summary>Opacity</summary>
     </key>
     <key name="icon-size" type="i">
-      <default>0</default>
+      <default>20</default>
       <summary>Icon size</summary>
       <description>Icon size in pixel</description>
     </key>


### PR DESCRIPTION
Some users their icons are "invisible" because the default size is set to 0. I chose size 20 because it makes most icons approximately the same size as the built-in top bar icons.

See: https://github.com/ubuntu/gnome-shell-extension-appindicator/issues/382