### PR TITLE
Add Gnome Shell 48

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,8 @@
     "shell-version": [
         "45",
         "46",
-        "47"
+        "47",
+        "48"
     ],
     "gettext-domain": "AppIndicatorExtension",
     "settings-schema": "org.gnome.shell.extensions.appindicator",


### PR DESCRIPTION
This patch add's Gnome Shell 48 to the metadata.json file.