### PR TITLE
metadata: Mark compatible with GNOME Shell 48

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,7 +2,8 @@
     "shell-version": [
         "45",
         "46",
-        "47"
+        "47",
+        "48"
     ],
     "gettext-domain": "AppIndicatorExtension",
     "settings-schema": "org.gnome.shell.extensions.appindicator",


### PR DESCRIPTION
### Tested on Arch Linux with following information

### extensions info
 gnome-extensions info  appindicatorsupport@rgcjonas.gmail.com
appindicatorsupport@rgcjonas.gmail.com
  Name: AppIndicator and KStatusNotifierItem Support
  Description: Adds AppIndicator, KStatusNotifierItem and legacy Tray icons support to the Shell
  Path: /home/martin/.local/share/gnome-shell/extensions/appindicatorsupport@rgcjonas.gmail.com
  URL: https://github.com/ubuntu/gnome-shell-extension-appindicator
  Version: 59
  Enabled: Yes
  State: ACTIVE
  
  ### system info
 gnome-shell --version
GNOME Shell 48.0

