### PR TITLE
Fix SIGSEGV crash in _getActivationToken when appInfo is null

### DIFF
--- a/appIndicator.js
+++ b/appIndicator.js
@@ -763,8 +763,10 @@ export class AppIndicator extends Signals.EventEmitter {
 
     _getActivationToken(timestamp) {
         const launchContext = global.create_app_launch_context(timestamp, -1);
+        // Ensure appName is never null to prevent crash in g_app_info_get_name()
+        const appName = this.id || this._commandLine || 'unknown';
         const fakeAppInfo = Gio.AppInfo.create_from_commandline(
-            this._commandLine || 'true', this.id,
+            this._commandLine || 'true', appName,
             Gio.AppInfoCreateFlags.SUPPORTS_STARTUP_NOTIFICATION);
         return [launchContext, launchContext.get_startup_notify_id(fakeAppInfo, [])];
     }

--- a/appIndicator.js
+++ b/appIndicator.js
@@ -768,6 +768,11 @@ export class AppIndicator extends Signals.EventEmitter {
         const fakeAppInfo = Gio.AppInfo.create_from_commandline(
             this._commandLine || 'true', appName,
             Gio.AppInfoCreateFlags.SUPPORTS_STARTUP_NOTIFICATION);
+
+        // Guard against null fakeAppInfo to prevent SIGSEGV in get_startup_notify_id()
+        if (!fakeAppInfo)
+            return [launchContext, null];
+
         return [launchContext, launchContext.get_startup_notify_id(fakeAppInfo, [])];
     }
 


### PR DESCRIPTION
## Summary

Fixes a crash (SIGSEGV) that occurs when clicking on certain tray icons. The crash happens in `_getActivationToken()` when:
1. `this.id` is null, causing `Gio.AppInfo.create_from_commandline()` to fail
2. The resulting null `fakeAppInfo` is passed to `get_startup_notify_id()`, which crashes in `g_app_info_get_name()` -> `strlen(NULL)`

## Changes

- **Commit 1:** Add fallback chain for `appName` (`this.id || this._commandLine || 'unknown'`) to ensure it's never null
- **Commit 2:** Add null guard for `fakeAppInfo` to gracefully handle cases where `create_from_commandline()` fails

## Crash Details

```
gnome-shell: g_app_info_get_name: assertion 'G_IS_APP_INFO (appinfo)' failed
gnome-shell: segfault at 0 ip 00007fda22157bdd ... in libc.so.6
```

### Stack Trace
```
#0  __strlen_avx2 (libc.so.6)
#1  sn_internal_strdup (libstartup-notification-1.so.0)
#2  sn_launcher_context_set_name (libstartup-notification-1.so.0)
#3  meta_launch_context_get_startup_notify_id (libmutter-16.so.0)
...
#37 st_button_button_release (libst-16.so)
```

## Reproduction

1. Have a tray application that registers without a valid `Id` property (observed with some Electron apps)
2. Click on the tray icon
3. GNOME Shell crashes with SIGSEGV

## Testing

- Verified the fix prevents the crash by ensuring `appName` and `fakeAppInfo` are never null
- Callers of `_getActivationToken()` (e.g., `provideActivationToken()`) already handle null `activationToken` gracefully

## Environment

- GNOME Shell 48.6
- Mutter 48.6
- Fedora 42
- Extension version 60