### PR TITLE
trayIconsManager: Remove panel style-changed handler to prevent race condition

### DIFF
--- a/trayIconsManager.js
+++ b/trayIconsManager.js
@@ -45,19 +45,6 @@ export class TrayIconsManager extends Signals.EventEmitter {
         this._changedId = SettingsManager.getDefaultGSettings().connect(
             'changed::legacy-tray-enabled', () => this._toggle());
 
-        // On theme changed, need to update the bg color to match style,
-        // This may not be required anymore on newer shell versions that use
-        // ARGBA visuals.
-        this._styleChangedID = Main.panel.connect('style-changed', () => {
-            const panelBgColor = this._getPanelBgColor();
-            const {bgColor} = this._tray ?? {bgColor: null};
-            if (bgColor === panelBgColor || bgColor?.equal(panelBgColor))
-                return;
-
-            this._disable();
-            this._toggle();
-        });
-
         this._toggle();
     }
 
@@ -110,7 +97,6 @@ export class TrayIconsManager extends Signals.EventEmitter {
     destroy() {
         this.emit('destroy');
         SettingsManager.getDefaultGSettings().disconnect(this._changedId);
-        Main.panel.disconnect(this._styleChangedID);
         this._disable();
         trayIconsManager = null;
     }


### PR DESCRIPTION
The panel style-changed handler would previously toggle on and off the tray manager when any style changes occurred on the panel. This led to race conditions that would sometimes crash GNOME Shell, especially when locking and unlocking the screen.

The crash appears to be related to the following bug in GNOME Shell: https://gitlab.gnome.org/GNOME/gnome-shell/-/issues/7447
It appears that the rapid toggling of the tray manager is most likely causing a window that has already been destroyed to be passed into na_xembed_set_background_color().

This commit removes the problematic code – which is already marked as potentially obsolete in its comment – to greatly reduce the likelihood of a crash occurring.
Based on our testing in Ubuntu 24.04 we were no longer able to replicate the crashes after applying this patch.

This PR should fix #596 