### PR TITLE
indicatorStatusIcon: Override new Clutter.ClickGesture

### DIFF
--- a/indicatorStatusIcon.js
+++ b/indicatorStatusIcon.js
@@ -246,6 +246,10 @@ class IndicatorStatusIcon extends BaseStatusIcon {
     _init(indicator) {
         super._init(0.5, indicator.accessibleName,
             new AppIndicator.IconActor(indicator, DEFAULT_ICON_SIZE));
+
+        // Disable upstream's click gesture and fall back to vfunc_button_press_event etc.
+        this._clickGesture?.set_enabled(false);
+
         this._indicator = indicator;
 
         this._lastClickTime = -1;


### PR DESCRIPTION
GNOME Shell 50 uses the new Clutter.ClickGesture to handle clicks. This takes precedence over the Clutter.Actor::button_press_event and similar vfuncs.

Disable the gesture, if it exists, and fall back to the vfuncs.

This maintains compatibility with older GNOME Shell versions.

Closes: https://github.com/ubuntu/gnome-shell-extension-appindicator/issues/614