### PR TITLE
indicatorStatusIcon: Add hide mode to toggle visibility of individual tray icons

### DIFF
--- a/appIndicator.js
+++ b/appIndicator.js
@@ -558,6 +558,26 @@ export class AppIndicator extends Signals.EventEmitter {
         return this._uniqueId;
     }
 
+    /**
+     * Stable, app-specific identifier used for hide/show persistence.
+     *
+     * Electron apps register SNI items with the same generic id
+     * `chrome_status_icon_1`, which makes Bitwarden, Telegram, Pritunl
+     * and similar apps indistinguishable from each other when stored
+     * in GSettings. To work around that we derive the basename of the
+     * executable from `_commandLine` and use it as the identifier.
+     * Non-Electron apps continue to use their SNI id.
+     */
+    get appId() {
+        if (this._commandLine && this.id?.startsWith('chrome_status_icon')) {
+            const exe = this._commandLine.trim().split(/\s+/)[0];
+            const basename = exe.split('/').pop();
+            if (basename)
+                return basename.toLowerCase();
+        }
+        return this.id;
+    }
+
     get status() {
         return this._proxy.Status;
     }

--- a/extension.js
+++ b/extension.js
@@ -18,6 +18,7 @@ import * as Extension from 'resource:///org/gnome/shell/extensions/extension.js'
 
 import * as StatusNotifierWatcher from './statusNotifierWatcher.js';
 import * as Interfaces from './interfaces.js';
+import * as OverflowManager from './overflowManager.js';
 import * as TrayIconsManager from './trayIconsManager.js';
 import * as Util from './util.js';
 import {Logger} from './logger.js';
@@ -54,6 +55,7 @@ export default class AppIndicatorExtension extends Extension.Extension {
         this._isEnabled = true;
         SettingsManager.initialize(this);
         Util.tryCleanupOldIndicators();
+        OverflowManager.OverflowManager.initialize();
         this._maybeEnableAfterNameAvailable();
         TrayIconsManager.TrayIconsManager.initialize();
     }
@@ -61,6 +63,7 @@ export default class AppIndicatorExtension extends Extension.Extension {
     disable() {
         this._isEnabled = false;
         TrayIconsManager.TrayIconsManager.destroy();
+        OverflowManager.OverflowManager.destroy();
 
         if (this._statusNotifierWatcher !== null) {
             this._statusNotifierWatcher.destroy();

--- a/indicatorStatusIcon.js
+++ b/indicatorStatusIcon.js
@@ -23,6 +23,7 @@ import * as AppDisplay from 'resource:///org/gnome/shell/ui/appDisplay.js';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import * as Panel from 'resource:///org/gnome/shell/ui/panel.js';
 import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
+import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
 
 import * as AppIndicator from './appIndicator.js';
 import * as OverflowManager from './overflowManager.js';
@@ -295,6 +296,11 @@ class IndicatorStatusIcon extends BaseStatusIcon {
 
         this.connect('notify::visible', () => this._updateMenu());
 
+        this.menu.connect('open-state-changed', (_menu, isOpen) => {
+            if (isOpen)
+                this._ensureManagementMenuItems();
+        });
+
         this._showIfReady();
     }
 
@@ -304,6 +310,9 @@ class IndicatorStatusIcon extends BaseStatusIcon {
             this._menuClient.destroy();
             this._menuClient = null;
         }
+
+        this._mgmtSeparator = null;
+        this._hideMenuItem = null;
 
         super._onDestroy();
     }
@@ -378,6 +387,61 @@ class IndicatorStatusIcon extends BaseStatusIcon {
         this._updateLabel();
         this._updateStatus();
         this._updateMenu();
+    }
+
+    /**
+     * Ensure that the "Hide from Panel" / "Show on Panel" entry exists
+     * at the bottom of the indicator's context menu while pin mode is
+     * enabled. Called every time the menu opens because the DBusMenu
+     * client may rebuild menu items asynchronously.
+     */
+    _ensureManagementMenuItems() {
+        const manager =
+            OverflowManager.OverflowManager.getDefault();
+        if (!manager || !this._indicator?.appId)
+            return;
+
+        const settings = SettingsManager.getDefaultGSettings();
+        if (!settings.get_boolean('pin-mode-enabled'))
+            return;
+
+        this._destroyManagementMenuItems();
+
+        const appId = this._indicator.appId;
+        const isHidden = manager.isHidden(appId);
+
+        this._mgmtSeparator =
+            new PopupMenu.PopupSeparatorMenuItem();
+        this._mgmtSeparator.connect('destroy', () => {
+            this._mgmtSeparator = null;
+        });
+
+        this._hideMenuItem = new PopupMenu.PopupMenuItem(
+            isHidden ? 'Show on Panel' : 'Hide from Panel'
+        );
+        this._hideMenuItem.connect('destroy', () => {
+            this._hideMenuItem = null;
+        });
+        this._hideMenuItem.connect('activate', () => {
+            if (isHidden)
+                manager.unhideIcon(appId);
+            else
+                manager.hideIcon(appId);
+        });
+
+        this.menu.addMenuItem(this._mgmtSeparator);
+        this.menu.addMenuItem(this._hideMenuItem);
+    }
+
+    _destroyManagementMenuItems() {
+        if (this._mgmtSeparator) {
+            this._mgmtSeparator.destroy();
+            this._mgmtSeparator = null;
+        }
+        if (this._hideMenuItem) {
+            this._hideMenuItem.destroy();
+            this._hideMenuItem = null;
+        }
     }
 
     _updateClickCount(event) {

--- a/indicatorStatusIcon.js
+++ b/indicatorStatusIcon.js
@@ -25,6 +25,7 @@ import * as Panel from 'resource:///org/gnome/shell/ui/panel.js';
 import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
 
 import * as AppIndicator from './appIndicator.js';
+import * as OverflowManager from './overflowManager.js';
 import * as PromiseUtils from './promiseUtils.js';
 import * as SettingsManager from './settingsManager.js';
 import * as Util from './util.js';
@@ -50,6 +51,12 @@ export function addIconToPanel(statusIcon) {
     Main.panel.addToStatusArea(indicatorId, statusIcon, 1,
         settings.get_string('tray-pos'));
 
+    if (statusIcon instanceof IndicatorStatusIcon) {
+        const manager = OverflowManager.OverflowManager.getDefault();
+        if (manager)
+            manager.registerIcon(statusIcon);
+    }
+
     Util.connectSmart(settings, 'changed::tray-pos', statusIcon, () =>
         addIconToPanel(statusIcon));
 }
@@ -68,6 +75,8 @@ export const BaseStatusIcon = GObject.registerClass(
 class IndicatorBaseStatusIcon extends PanelMenu.Button {
     _init(menuAlignment, nameText, iconActor, dontCreateMenu) {
         super._init(menuAlignment, nameText, dontCreateMenu);
+
+        this._isOverflowed = false;
 
         const settings = SettingsManager.getDefaultGSettings();
         Util.connectSmart(settings, 'changed::icon-opacity', this, this._updateOpacity);
@@ -126,7 +135,21 @@ class IndicatorBaseStatusIcon extends PanelMenu.Button {
         throw new GObject.NotImplementedError('uniqueId in %s'.format(this.constructor.name));
     }
 
+    setOverflowed(overflowed) {
+        if (this._isOverflowed === overflowed)
+            return;
+        this._isOverflowed = overflowed;
+        if (overflowed)
+            this.visible = false;
+        else
+            this._showIfReady();
+    }
+
     _showIfReady() {
+        if (this._isOverflowed) {
+            this.visible = false;
+            return;
+        }
         this.visible = this.isReady();
     }
 

--- a/overflowButton.js
+++ b/overflowButton.js
@@ -1,0 +1,184 @@
+// This file is part of the AppIndicator/KStatusNotifierItem GNOME Shell extension
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import Clutter from 'gi://Clutter';
+import GObject from 'gi://GObject';
+import St from 'gi://St';
+
+import * as PanelMenu from 'resource:///org/gnome/shell/ui/panelMenu.js';
+import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
+
+import * as DBusMenu from './dbusMenu.js';
+import * as OverflowManagerModule from './overflowManager.js';
+import * as SettingsManager from './settingsManager.js';
+import * as WindowManager from './windowManager.js';
+
+const FALLBACK_ICON_NAME = 'application-x-executable-symbolic';
+
+export const OverflowButton = GObject.registerClass(
+class IndicatorOverflowButton extends PanelMenu.Button {
+    _init() {
+        super._init(0.5, 'Indicator Overflow');
+
+        // Disable ClickGesture from PanelMenu.Button to prevent
+        // menu-switching when hovering over other panel elements.
+        this._clickGesture?.set_enabled(false);
+
+        this._menuClients = [];
+
+        this._menuClients = [];
+
+        const box = new St.BoxLayout({
+            style_class: 'panel-status-indicators-box',
+        });
+        const icon = new St.Icon({
+            icon_name: 'pan-down-symbolic',
+            style_class: 'system-status-icon',
+        });
+        box.add_child(icon);
+        this.add_child(box);
+
+        this._applyStyle();
+    }
+
+    vfunc_event(event) {
+        if (event.type() === Clutter.EventType.TOUCH_BEGIN ||
+            event.type() === Clutter.EventType.BUTTON_PRESS) {
+            this.menu?.toggle();
+            return Clutter.EVENT_STOP;
+        }
+        return Clutter.EVENT_PROPAGATE;
+    }
+
+    _applyStyle() {
+        const settings = SettingsManager.getDefaultGSettings();
+        if (settings.get_boolean('compact-mode-enabled'))
+            this.set_style('-natural-hpadding: 10px');
+        else
+            this.set_style(null);
+    }
+
+    updateMenu(overflowedIcons) {
+        this._destroyMenuClients();
+        this.menu.removeAll();
+
+        for (const statusIcon of overflowedIcons) {
+            const indicator = statusIcon._indicator;
+            if (!indicator)
+                continue;
+
+            const appId = indicator.appId;
+            const label = indicator.title || appId || 'Unknown';
+
+            // Use PopupSubMenuMenuItem: left click = activate window,
+            // right click / expand arrow = show app menu + "Show on Panel"
+            const subMenu =
+                new PopupMenu.PopupSubMenuMenuItem(label);
+
+            // Use gicon from the actual tray icon for proper rendering
+            const gicon = statusIcon._icon?.gicon;
+            const menuIcon = gicon
+                ? new St.Icon({gicon, style_class: 'popup-menu-icon'})
+                : new St.Icon({
+                    icon_name: FALLBACK_ICON_NAME,
+                    style_class: 'popup-menu-icon',
+                });
+            subMenu.insert_child_below(
+                menuIcon, subMenu.label);
+
+            // Left click on the row = activate/toggle window + close overflow
+            subMenu.connect('button-press-event', (_actor, event) => {
+                if (event.get_button() === Clutter.BUTTON_PRIMARY) {
+                    if (!WindowManager.toggleWindows(indicator))
+                        indicator.open(
+                            ...event.get_coords(), event.get_time());
+                    this.menu.close();
+                    return Clutter.EVENT_STOP;
+                }
+                return Clutter.EVENT_PROPAGATE;
+            });
+
+            this._attachIndicatorMenu(
+                subMenu, indicator);
+
+            this.menu.addMenuItem(subMenu);
+        }
+
+        this.visible = overflowedIcons.length > 0;
+    }
+
+    _attachIndicatorMenu(subMenu, indicator) {
+        if (!indicator.menuPath) {
+            // No DBus menu — just add management items
+            this._addManagementItems(subMenu, indicator);
+            return;
+        }
+
+        const client = new DBusMenu.Client(
+            indicator.busName,
+            indicator.menuPath,
+            indicator
+        );
+
+        const attach = () => {
+            client.attachToMenu(subMenu.menu);
+            // Add "Show on Panel" AFTER DBus menu items
+            // (attachToMenu calls removeAll, so we must add after)
+            this._addManagementItems(subMenu, indicator);
+        };
+
+        if (client.isReady)
+            attach();
+
+        const readyId = client.connect('ready-changed', () => {
+            if (client.isReady)
+                attach();
+        });
+        this._menuClients.push({client, readyId});
+    }
+
+    _addManagementItems(subMenu, indicator) {
+        const manager =
+            OverflowManagerModule.OverflowManager.getDefault();
+        if (!manager || !indicator.appId)
+            return;
+
+        const separator =
+            new PopupMenu.PopupSeparatorMenuItem();
+        subMenu.menu.addMenuItem(separator);
+
+        const showItem = new PopupMenu.PopupMenuItem(
+            'Show on Panel'
+        );
+        showItem.connect('activate', () => {
+            manager.unhideIcon(indicator.appId);
+        });
+        subMenu.menu.addMenuItem(showItem);
+    }
+
+    _destroyMenuClients() {
+        for (const {client, readyId} of this._menuClients) {
+            client.disconnect(readyId);
+            client.destroy();
+        }
+        this._menuClients = [];
+    }
+
+    _onDestroy() {
+        this._destroyMenuClients();
+        super._onDestroy();
+    }
+});

--- a/overflowManager.js
+++ b/overflowManager.js
@@ -1,0 +1,304 @@
+// This file is part of the AppIndicator/KStatusNotifierItem GNOME Shell extension
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import GLib from 'gi://GLib';
+
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import * as Signals from 'resource:///org/gnome/shell/misc/signals.js';
+
+import {SNIStatus} from './appIndicator.js';
+import * as StatusIcon from './indicatorStatusIcon.js';
+import {OverflowButton} from './overflowButton.js';
+import * as SettingsManager from './settingsManager.js';
+import * as Util from './util.js';
+
+let overflowManager;
+
+export class OverflowManager extends Signals.EventEmitter {
+    static initialize() {
+        if (!overflowManager)
+            overflowManager = new OverflowManager();
+        return overflowManager;
+    }
+
+    static destroy() {
+        if (overflowManager) {
+            overflowManager.destroy();
+            overflowManager = null;
+        }
+    }
+
+    static getDefault() {
+        return overflowManager;
+    }
+
+    constructor() {
+        super();
+
+        if (overflowManager)
+            throw new Error('OverflowManager is already constructed');
+
+        this._trackedIcons = new Map();
+        this._overflowButton = null;
+        this._updateTimeoutId = 0;
+
+        const settings = SettingsManager.getDefaultGSettings();
+        this._settingsChangedIds = [
+            settings.connect('changed::pin-mode-enabled',
+                () => this._scheduleUpdate()),
+            settings.connect('changed::hidden-icons',
+                () => this._scheduleUpdate()),
+            settings.connect('changed::tray-pos',
+                () => this._onTrayPosChanged()),
+        ];
+    }
+
+    registerIcon(statusIcon) {
+        if (this._trackedIcons.has(statusIcon.uniqueId))
+            return;
+
+        this._trackedIcons.set(statusIcon.uniqueId, statusIcon);
+
+        statusIcon.connect('destroy', () => {
+            this._trackedIcons.delete(statusIcon.uniqueId);
+            this._scheduleUpdate();
+        });
+
+        if (statusIcon._indicator) {
+            Util.connectSmart(statusIcon._indicator, 'ready',
+                this, () => {
+                    this._recordKnownIndicator(statusIcon);
+                    this._scheduleUpdate();
+                    // Re-check after commandLine loads (needed for
+                    // Electron apps sharing chrome_status_icon_1 ID)
+                    this._scheduleDelayedUpdate();
+                });
+            Util.connectSmart(statusIcon._indicator, 'status',
+                this, () => this._scheduleUpdate());
+        }
+
+        this._recordKnownIndicator(statusIcon);
+        this._scheduleUpdate();
+    }
+
+    hideIcon(indicatorId) {
+        const settings = SettingsManager.getDefaultGSettings();
+        const hidden = settings.get_strv('hidden-icons');
+        if (!hidden.includes(indicatorId)) {
+            hidden.push(indicatorId);
+            settings.set_strv('hidden-icons', hidden);
+        }
+    }
+
+    unhideIcon(indicatorId) {
+        const settings = SettingsManager.getDefaultGSettings();
+        const hidden = settings.get_strv('hidden-icons');
+        const filtered =
+            hidden.filter(id => id !== indicatorId);
+        if (filtered.length !== hidden.length)
+            settings.set_strv('hidden-icons', filtered);
+    }
+
+    isHidden(indicatorId) {
+        const settings = SettingsManager.getDefaultGSettings();
+        return settings.get_strv('hidden-icons')
+            .includes(indicatorId);
+    }
+
+    _recordKnownIndicator(statusIcon) {
+        const indicator = statusIcon._indicator;
+        if (!indicator?.appId)
+            return;
+
+        const settings = SettingsManager.getDefaultGSettings();
+        const known = settings.get_value('known-indicators')
+            .deep_unpack();
+        const id = indicator.appId;
+        const title = indicator.title || indicator.id || id;
+
+        const idx = known.findIndex(pair => pair[0] === id);
+        if (idx >= 0) {
+            if (known[idx][1] === title)
+                return;
+            known[idx][1] = title;
+        } else {
+            known.push([id, title]);
+        }
+
+        settings.set_value('known-indicators',
+            new GLib.Variant('a(ss)', known));
+    }
+
+    _scheduleUpdate() {
+        if (this._updateTimeoutId)
+            return;
+
+        this._updateTimeoutId = GLib.idle_add(
+            GLib.PRIORITY_DEFAULT, () => {
+                this._updateTimeoutId = 0;
+                this._updateVisibility();
+                return GLib.SOURCE_REMOVE;
+            });
+    }
+
+    _scheduleDelayedUpdate() {
+        if (this._delayedUpdateId)
+            return;
+
+        // Re-check after 3s — gives time for _commandLine to load
+        this._delayedUpdateId = GLib.timeout_add(
+            GLib.PRIORITY_DEFAULT, 3000, () => {
+                this._delayedUpdateId = 0;
+                // Re-record known indicators with resolved appIds
+                for (const icon of this._trackedIcons.values())
+                    this._recordKnownIndicator(icon);
+                this._updateVisibility();
+                return GLib.SOURCE_REMOVE;
+            });
+    }
+
+    _updateVisibility() {
+        const settings = SettingsManager.getDefaultGSettings();
+        const pinMode =
+            settings.get_boolean('pin-mode-enabled');
+
+        const allIcons = [...this._trackedIcons.values()];
+
+        // Classic mode: show everything, no overflow
+        if (!pinMode) {
+            for (const icon of allIcons)
+                icon.setOverflowed(false);
+            this._updateOverflowButton([]);
+            return;
+        }
+
+        // Hide mode: all visible by default, hidden go to overflow
+        const hiddenIds = settings.get_strv('hidden-icons');
+
+        // Active icons: ready and not PASSIVE
+        const activeIcons = allIcons.filter(icon =>
+            icon._indicator &&
+            icon._indicator.isReady &&
+            icon._indicator.status !== SNIStatus.PASSIVE
+        );
+
+        const visibleIcons = activeIcons.filter(icon =>
+            !icon._indicator.appId ||
+            !hiddenIds.includes(icon._indicator.appId)
+        );
+
+        const hiddenIcons = activeIcons.filter(icon =>
+            icon._indicator.appId &&
+            hiddenIds.includes(icon._indicator.appId)
+        );
+
+        // Visible icons — shown on panel
+        for (const icon of visibleIcons)
+            icon.setOverflowed(false);
+
+        // Hidden icons — go to overflow
+        const overflowedIcons = [];
+        for (const icon of hiddenIcons) {
+            icon.setOverflowed(true);
+            overflowedIcons.push(icon);
+        }
+
+        // Inactive icons — not overflowed (own logic hides them)
+        const inactiveIcons = allIcons.filter(icon =>
+            !activeIcons.includes(icon)
+        );
+        for (const icon of inactiveIcons)
+            icon.setOverflowed(false);
+
+        this._updateOverflowButton(overflowedIcons);
+    }
+
+    _updateOverflowButton(overflowedIcons) {
+        if (overflowedIcons.length > 0) {
+            if (!this._overflowButton) {
+                this._overflowButton = new OverflowButton();
+                this._addOverflowButtonToPanel();
+            }
+            this._overflowButton.updateMenu(overflowedIcons);
+        } else if (this._overflowButton) {
+            this._overflowButton.destroy();
+            this._overflowButton = null;
+        }
+    }
+
+    _addOverflowButtonToPanel() {
+        if (!this._overflowButton)
+            return;
+
+        const settings = SettingsManager.getDefaultGSettings();
+        const indicatorId = 'appindicator-overflow';
+
+        const currentButton =
+            Main.panel.statusArea[indicatorId];
+        if (currentButton) {
+            if (currentButton !== this._overflowButton)
+                currentButton.destroy();
+            Main.panel.statusArea[indicatorId] = null;
+        }
+
+        Main.panel.addToStatusArea(indicatorId,
+            this._overflowButton, -1,
+            settings.get_string('tray-pos'));
+
+        this._overflowButton._appIndicatorOwned = true;
+
+        // Patch menuManager to skip hover-switching for overflow button
+        if (this._overflowButton.menu) {
+            StatusIcon.patchMenuManager();
+            this._overflowButton.menu.connect('open-state-changed',
+                (_m, isOpen) => { StatusIcon.setTrayMenuOpen(isOpen); });
+        }
+    }
+
+    _onTrayPosChanged() {
+        if (this._overflowButton)
+            this._addOverflowButtonToPanel();
+    }
+
+    destroy() {
+        this.emit('destroy');
+
+        if (this._updateTimeoutId) {
+            GLib.source_remove(this._updateTimeoutId);
+            this._updateTimeoutId = 0;
+        }
+
+        if (this._delayedUpdateId) {
+            GLib.source_remove(this._delayedUpdateId);
+            this._delayedUpdateId = 0;
+        }
+
+        if (this._overflowButton) {
+            this._overflowButton.destroy();
+            this._overflowButton = null;
+        }
+
+        const settings = SettingsManager.getDefaultGSettings();
+        for (const id of this._settingsChangedIds)
+            settings.disconnect(id);
+        this._settingsChangedIds = [];
+
+        for (const icon of this._trackedIcons.values())
+            icon.setOverflowed(false);
+
+        this._trackedIcons.clear();
+    }
+}

--- a/preferences/generalPage.js
+++ b/preferences/generalPage.js
@@ -92,6 +92,19 @@ class AppIndicatorGeneralPage extends Adw.PreferencesPage {
             round: true,
         });
 
+        const pinModeSwitch = new Adw.SwitchRow({
+            title: _('Pin Mode'),
+            subtitle: _('Right-click indicators to hide them '
+                + 'into the overflow menu'),
+            active: this._settings.get_boolean(
+                this._settingsKey.PIN_MODE_ENABLED),
+        });
+        pinModeSwitch.connect('notify::active', widget =>
+            this._settings.set_boolean(
+                this._settingsKey.PIN_MODE_ENABLED,
+                widget.get_active()));
+        this.group.add(pinModeSwitch);
+
         const alignmentList = new Gtk.StringList();
         const comboItems = [
             {pos: 'center', label: _('Center')},

--- a/preferences/indicatorPage.js
+++ b/preferences/indicatorPage.js
@@ -1,0 +1,233 @@
+/* exported IndicatorPage */
+
+import Adw from 'gi://Adw';
+import Gio from 'gi://Gio';
+import Gtk from 'gi://Gtk';
+import GObject from 'gi://GObject';
+import GLib from 'gi://GLib';
+import {
+    gettext as _,
+} from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
+
+const IndicatorData = GObject.registerClass({
+    GTypeName: 'IndicatorData',
+    Properties: {
+        'indicator-id': GObject.ParamSpec.string(
+            'indicator-id', 'Indicator ID',
+            'The SNI indicator identifier',
+            GObject.ParamFlags.READWRITE, ''
+        ),
+        'title': GObject.ParamSpec.string(
+            'title', 'Title',
+            'The display title of the indicator',
+            GObject.ParamFlags.READWRITE, ''
+        ),
+        'hidden': GObject.ParamSpec.boolean(
+            'hidden', 'Hidden',
+            'Whether the indicator is hidden from the panel',
+            GObject.ParamFlags.READWRITE, false
+        ),
+    },
+}, class IndicatorData extends GObject.Object {
+    constructor(props = {}) {
+        super(props);
+    }
+
+    get indicatorId() {
+        return this._indicatorId || '';
+    }
+
+    set indicatorId(value) {
+        if (this._indicatorId === value)
+            return;
+        this._indicatorId = value;
+        this.notify('indicator-id');
+    }
+
+    get title() {
+        return this._title || '';
+    }
+
+    set title(value) {
+        if (this._title === value)
+            return;
+        this._title = value;
+        this.notify('title');
+    }
+
+    get hidden() {
+        return this._hidden || false;
+    }
+
+    set hidden(value) {
+        if (this._hidden === value)
+            return;
+        this._hidden = value;
+        this.notify('hidden');
+    }
+});
+
+export var IndicatorPage = GObject.registerClass(
+class AppIndicatorIndicatorPage extends Adw.PreferencesPage {
+    _init(settings, settingsKey) {
+        super._init({
+            title: _('Indicators'),
+            icon_name: 'view-list-symbolic',
+            name: 'Indicators Page',
+        });
+
+        this._settings = settings;
+        this._settingsKey = settingsKey;
+        this._updating = false;
+
+        const group = new Adw.PreferencesGroup({
+            title: _('Indicator Management'),
+            description: _(
+                'Hide indicators from the panel when Pin Mode is enabled. '
+                + 'Hidden indicators go to the overflow menu.'
+            ),
+        });
+
+        this._listBox = new Gtk.ListBox({
+            selection_mode: Gtk.SelectionMode.NONE,
+            css_classes: ['boxed-list'],
+        });
+
+        this._listStore = new Gio.ListStore({
+            item_type: IndicatorData,
+        });
+
+        this._listBox.bind_model(
+            this._listStore, item => this._createRow(item)
+        );
+
+        group.add(this._listBox);
+        this.add(group);
+
+        this._syncFromSettings();
+
+        this._settingsChangedIds = [
+            this._settings.connect(
+                `changed::${this._settingsKey.KNOWN_INDICATORS}`,
+                () => this._syncFromSettings()
+            ),
+            this._settings.connect(
+                `changed::${this._settingsKey.HIDDEN_ICONS}`,
+                () => this._syncFromSettings()
+            ),
+        ];
+
+        this.connect('destroy', () => {
+            for (const id of this._settingsChangedIds)
+                this._settings.disconnect(id);
+            this._settingsChangedIds = [];
+        });
+    }
+
+    _syncFromSettings() {
+        if (this._updating)
+            return;
+
+        const known = this._settings.get_value(
+            this._settingsKey.KNOWN_INDICATORS
+        ).deep_unpack();
+        const hiddenIds = this._settings.get_strv(
+            this._settingsKey.HIDDEN_ICONS
+        );
+
+        this._listStore.remove_all();
+
+        for (const [id, title] of known) {
+            this._listStore.append(new IndicatorData({
+                indicatorId: id,
+                title: title || id,
+                hidden: hiddenIds.includes(id),
+            }));
+        }
+    }
+
+    _createRow(item) {
+        const row = new Adw.ActionRow({
+            title: GLib.markup_escape_text(item.title, -1),
+            subtitle: GLib.markup_escape_text(
+                item.indicatorId, -1
+            ),
+        });
+
+        const hiddenSwitch = new Gtk.Switch({
+            active: item.hidden,
+            valign: Gtk.Align.CENTER,
+            tooltip_text: _('Hide from Panel'),
+        });
+        hiddenSwitch.connect('notify::active', sw => {
+            this._setIconHidden(
+                item.indicatorId, sw.get_active()
+            );
+        });
+
+        const removeButton = new Gtk.Button({
+            icon_name: 'user-trash-symbolic',
+            valign: Gtk.Align.CENTER,
+            css_classes: ['flat'],
+            tooltip_text: _('Remove'),
+        });
+        removeButton.connect('clicked', () => {
+            this._removeKnownIndicator(item.indicatorId);
+        });
+
+        const hiddenBox = new Gtk.Box({
+            orientation: Gtk.Orientation.HORIZONTAL,
+            spacing: 4,
+            valign: Gtk.Align.CENTER,
+        });
+        hiddenBox.append(new Gtk.Label({
+            label: _('Hide'),
+            css_classes: ['dim-label'],
+        }));
+        hiddenBox.append(hiddenSwitch);
+
+        row.add_suffix(hiddenBox);
+        row.add_suffix(removeButton);
+
+        return row;
+    }
+
+    _setIconHidden(indicatorId, hidden) {
+        this._updating = true;
+        const hiddenIds = this._settings.get_strv(
+            this._settingsKey.HIDDEN_ICONS
+        );
+        if (hidden && !hiddenIds.includes(indicatorId)) {
+            hiddenIds.push(indicatorId);
+            this._settings.set_strv(
+                this._settingsKey.HIDDEN_ICONS, hiddenIds
+            );
+        } else if (!hidden) {
+            const filtered =
+                hiddenIds.filter(id => id !== indicatorId);
+            if (filtered.length !== hiddenIds.length) {
+                this._settings.set_strv(
+                    this._settingsKey.HIDDEN_ICONS, filtered
+                );
+            }
+        }
+        this._updating = false;
+    }
+
+    _removeKnownIndicator(indicatorId) {
+        this._updating = true;
+        const known = this._settings.get_value(
+            this._settingsKey.KNOWN_INDICATORS
+        ).deep_unpack();
+        const filtered =
+            known.filter(pair => pair[0] !== indicatorId);
+        if (filtered.length !== known.length) {
+            this._settings.set_value(
+                this._settingsKey.KNOWN_INDICATORS,
+                new GLib.Variant('a(ss)', filtered)
+            );
+        }
+        this._updating = false;
+        this._syncFromSettings();
+    }
+});

--- a/prefs.js
+++ b/prefs.js
@@ -6,6 +6,7 @@ import Gtk from 'gi://Gtk';  // will be removed
 import Gdk from 'gi://Gdk';
 import * as GeneralPreferences from './preferences/generalPage.js';
 import * as CustomIconPreferences from './preferences/customIconPage.js';
+import * as IndicatorPreferences from './preferences/indicatorPage.js';
 
 import {
     ExtensionPreferences,
@@ -22,6 +23,9 @@ const SettingsKey = {
     ICON_CONTRAST: 'icon-contrast',
     TRAY_POS: 'tray-pos',
     CUSTOM_ICONS: 'custom-icons',
+    PIN_MODE_ENABLED: 'pin-mode-enabled',
+    HIDDEN_ICONS: 'hidden-icons',
+    KNOWN_INDICATORS: 'known-indicators',
 };
 
 export default class DockPreferences extends ExtensionPreferences {
@@ -34,9 +38,11 @@ export default class DockPreferences extends ExtensionPreferences {
         const settings = this.getSettings();
         const generalPage = new GeneralPreferences.GeneralPage(settings, SettingsKey);
         const customIconPage = new CustomIconPreferences.CustomIconPage(settings, SettingsKey);
+        const indicatorPage = new IndicatorPreferences.IndicatorPage(settings, SettingsKey);
 
         window.add(generalPage);
         window.add(customIconPage);
+        window.add(indicatorPage);
 
         window.connect('close-request', () => {
             window.destroy();

--- a/schemas/org.gnome.shell.extensions.appindicator.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.appindicator.gschema.xml
@@ -45,5 +45,20 @@
       <summary>Custom icons</summary>
       <description>Replace any icons with custom icons from themes</description>
     </key>
+    <key name="pin-mode-enabled" type="b">
+      <default>false</default>
+      <summary>Enable hide mode</summary>
+      <description>When enabled, indicators marked as hidden are moved from the panel into an overflow menu.</description>
+    </key>
+    <key name="hidden-icons" type="as">
+      <default>[]</default>
+      <summary>Hidden indicator IDs</summary>
+      <description>List of indicator IDs hidden from the panel into the overflow menu.</description>
+    </key>
+    <key name="known-indicators" type="a(ss)">
+      <default>[]</default>
+      <summary>Known indicators</summary>
+      <description>List of (appId, title) pairs for indicators seen by the extension, used by the preferences UI to manage hidden icons.</description>
+    </key>
   </schema>
 </schemalist>

--- a/windowManager.js
+++ b/windowManager.js
@@ -1,0 +1,102 @@
+// This file is part of the AppIndicator/KStatusNotifierItem GNOME Shell extension
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+import Shell from 'gi://Shell';
+
+const WindowTracker = Shell.WindowTracker.get_default();
+
+/**
+ * Toggle windows for an indicator: activate if not focused,
+ * minimize if focused, or fall through if no windows found.
+ *
+ * @param {AppIndicator} indicator - the SNI indicator
+ * @returns {boolean} true if handled, false to fall through
+ */
+export function toggleWindows(indicator) {
+    const app = _findApp(indicator);
+    if (!app)
+        return false;
+
+    const windows = app.get_windows();
+    if (!windows.length)
+        return false;
+
+    const focusedApp = WindowTracker.focusApp;
+    if (focusedApp && focusedApp.get_id() === app.get_id()) {
+        for (const win of windows)
+            win.minimize();
+        return true;
+    }
+
+    for (const win of windows) {
+        win.unminimize();
+        app.activate_window(
+            win, global.get_current_time());
+    }
+    return true;
+}
+
+function _findApp(indicator) {
+    if (!indicator?.id)
+        return null;
+
+    const appSystem = Shell.AppSystem.get_default();
+    const id = indicator.id.toLowerCase();
+    const title = indicator.title?.toLowerCase();
+    const cmdLine = indicator._commandLine?.toLowerCase();
+
+    // Try direct desktop-file lookup
+    for (const suffix of ['', '.desktop']) {
+        const app = appSystem.lookup_app(indicator.id + suffix);
+        if (app?.get_windows().length)
+            return app;
+    }
+
+    // Match by command line first (reliable for Electron apps sharing same SNI ID)
+    if (cmdLine) {
+        for (const app of appSystem.get_running()) {
+            if (!app.get_windows().length)
+                continue;
+
+            const appId = app.get_id()?.toLowerCase().replace('.desktop', '');
+            if (appId && cmdLine.includes(appId))
+                return app;
+        }
+    }
+
+    // Match by wm_class among running apps
+    for (const app of appSystem.get_running()) {
+        const windows = app.get_windows();
+        if (!windows.length)
+            continue;
+
+        const wmClass = windows[0].get_wm_class()?.toLowerCase();
+        const appId = app.get_id()?.toLowerCase();
+
+        if (wmClass && id && (wmClass.includes(id) || id.includes(wmClass)))
+            return app;
+        if (wmClass && title && (wmClass.includes(title) || title.includes(wmClass)))
+            return app;
+        if (appId && id && appId.includes(id))
+            return app;
+
+        // Match command line against wm_class
+        if (wmClass && cmdLine && cmdLine.includes(wmClass))
+            return app;
+    }
+
+    return null;
+}


### PR DESCRIPTION
## Summary

Adds a "Pin Mode" setting that lets users selectively hide tray icons into an overflow menu, addressing the long-requested ability to declutter the panel.

### Features

- **Hide mode** (blacklist approach): all icons visible by default, right-click → "Hide from Panel" to move specific icons to overflow
- **Overflow button** (˅): shows hidden icons with app submenus + "Show on Panel" action; left-click activates the app window
- **Preferences UI**: new "Indicators" tab listing all known indicators with Hide toggle and Remove button
- **Electron app support**: unique `appId` per Electron app (Bitwarden, Pritunl, etc.) instead of shared `chrome_status_icon_1`
- **Click behavior**: left-click = toggle app window, right-click = context menu, middle-click = SecondaryActivate
- **Menu isolation**: prevent hover-switching between tray menus and system indicators

### New files
- `overflowButton.js` — overflow popup menu for hidden icons
- `overflowManager.js` — hide/unhide logic, visibility management
- `windowManager.js` — toggle windows on left-click (minimize if focused, activate if not)
- `preferences/indicatorPage.js` — Indicators preferences page

### New GSettings keys
| Key | Type | Description |
|-----|------|-------------|
| `pin-mode-enabled` | `b` | Enable/disable hide mode |
| `hidden-icons` | `as` | List of hidden `appId` strings |
| `known-indicators` | `a(ss)` | Pairs of (appId, title) seen by extension |

### Technical notes
- Disables `Clutter.ClickGesture` on tray icons (GNOME 50+ uses gesture instead of `vfunc_event`)
- `vfunc_event` defined in `BaseStatusIcon` (first GJS subclass of C type) for reliable vfunc override
- `appId` getter uses executable basename from `/proc/PID/cmdline` for Electron apps
- Delayed re-check (3s after `ready`) to resolve Electron appIds after commandLine loads

Closes: https://github.com/ubuntu/gnome-shell-extension-appindicator/issues/175