### PR TITLE
menuUtils: Fix menu items disappearing when moved past the last row

### DIFF
--- a/.github/workflows/dist-check-and-ego-upload.yaml
+++ b/.github/workflows/dist-check-and-ego-upload.yaml
@@ -25,6 +25,7 @@ jobs:
         sudo apt install -y \
           jq \
           gettext \
+          gjs \
           meson \
           zip
 

--- a/dbusMenu.js
+++ b/dbusMenu.js
@@ -25,6 +25,7 @@ import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
 import * as Signals from 'resource:///org/gnome/shell/misc/signals.js';
 
 import * as DBusInterfaces from './interfaces.js';
+import * as MenuUtils from './menuUtils.js';
 import * as PromiseUtils from './promiseUtils.js';
 import * as Util from './util.js';
 import {DBusProxy} from './dbusProxy.js';
@@ -814,33 +815,6 @@ const MenuItemFactory = {
 
         // now destroy our old self
         this.destroy();
-    },
-};
-
-/**
- * Utility functions not necessarily belonging into the item factory
- */
-const MenuUtils = {
-    moveItemInMenu(menu, dbusItem, newpos) {
-        // HACK: we're really getting into the internals of the PopupMenu implementation
-
-        // First, find our wrapper. Children tend to lie. We do not trust the old positioning.
-        const family = menu._getMenuItems();
-        for (let i = 0; i < family.length; ++i) {
-            if (family[i]._dbusItem === dbusItem) {
-                // now, remove it
-                menu.box.remove_child(family[i]);
-
-                // and add it again somewhere else
-                if (newpos < family.length && family[newpos] !== family[i])
-                    menu.box.insert_child_below(family[i], family[newpos]);
-                else
-                    menu.box.add(family[i]);
-
-                // skip the rest
-                return;
-            }
-        }
     },
 };
 

--- a/menuUtils.js
+++ b/menuUtils.js
@@ -1,0 +1,42 @@
+// This file is part of the AppIndicator/KStatusNotifierItem GNOME Shell extension
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+
+/**
+ * Utility functions not necessarily belonging into the item factory
+ */
+
+export function moveItemInMenu(menu, dbusItem, newpos) {
+    // HACK: we're really getting into the internals of the PopupMenu implementation
+
+    // First, find our wrapper. Children tend to lie. We do not trust the old positioning.
+    const family = menu._getMenuItems();
+    for (let i = 0; i < family.length; ++i) {
+        if (family[i]._dbusItem === dbusItem) {
+            // now, remove it
+            menu.box.remove_child(family[i]);
+
+            // and add it again somewhere else
+            if (newpos < family.length && family[newpos] !== family[i])
+                menu.box.insert_child_below(family[i], family[newpos]);
+            else
+                menu.box.add(family[i]);
+
+            // skip the rest
+            return;
+        }
+    }
+}

--- a/menuUtils.js
+++ b/menuUtils.js
@@ -33,7 +33,7 @@ export function moveItemInMenu(menu, dbusItem, newpos) {
             if (newpos < family.length && family[newpos] !== family[i])
                 menu.box.insert_child_below(family[i], family[newpos]);
             else
-                menu.box.add(family[i]);
+                menu.box.add_child(family[i]);
 
             // skip the rest
             return;

--- a/meson.build
+++ b/meson.build
@@ -55,6 +55,14 @@ subdir('schemas')
 subdir('locale')
 
 
+gjs = find_program('gjs', required: false)
+if gjs.found()
+    test('menu-utils',
+        gjs,
+        args: ['-m', files('tests/testMenuUtils.js')],
+        protocol: 'tap')
+endif
+
 eslint = find_program('eslint', required: false)
 if eslint.found()
     test('eslint',
@@ -86,6 +94,7 @@ summary({
     'Extension UUID': uuid,
     'Gettext domain': gettext_domain,
     'ESLint': eslint.found(),
+    'GJS': gjs.found(),
     },
     section: 'Configuration')
 

--- a/tests/testMenuUtils.js
+++ b/tests/testMenuUtils.js
@@ -1,0 +1,106 @@
+#!/usr/bin/gjs -m
+// This file is part of the AppIndicator/KStatusNotifierItem GNOME Shell extension
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+
+import System from 'system';
+
+import * as MenuUtils from '../menuUtils.js';
+
+/**
+ * A stand-in for the St.BoxLayout backing a PopupMenu, exposing the actor
+ * API that gnome-shell uses to arrange menu rows
+ */
+class FakeBox {
+    constructor(children) {
+        this._children = [...children];
+    }
+
+    get_children() {
+        return [...this._children];
+    }
+
+    add_child(child) {
+        this._children.push(child);
+    }
+
+    insert_child_below(child, sibling) {
+        this._children.splice(this._children.indexOf(sibling), 0, child);
+    }
+
+    remove_child(child) {
+        this._children.splice(this._children.indexOf(child), 1);
+    }
+}
+
+class FakeMenu {
+    constructor(dbusItems) {
+        this.box = new FakeBox(dbusItems.map(dbusItem => ({_dbusItem: dbusItem})));
+    }
+
+    _getMenuItems() {
+        return this.box.get_children();
+    }
+}
+
+function assertOrder(menu, expected) {
+    const actual = menu._getMenuItems().map(item => item._dbusItem);
+
+    if (actual.join(' ') !== expected.join(' '))
+        throw new Error(`expected [${expected}], got [${actual}]`);
+}
+
+const tests = [
+    ['moves a row towards the front of the menu', () => {
+        const menu = new FakeMenu(['first', 'second', 'third']);
+
+        MenuUtils.moveItemInMenu(menu, 'third', 0);
+
+        assertOrder(menu, ['third', 'first', 'second']);
+    }],
+    ['appends a row moved past the last one', () => {
+        // rows lag behind the item list while additions are still queued
+        const menu = new FakeMenu(['first', 'second']);
+
+        MenuUtils.moveItemInMenu(menu, 'first', 2);
+
+        assertOrder(menu, ['second', 'first']);
+    }],
+    ['leaves the menu alone for an item that has no row', () => {
+        const menu = new FakeMenu(['first', 'second']);
+
+        MenuUtils.moveItemInMenu(menu, 'third', 0);
+
+        assertOrder(menu, ['first', 'second']);
+    }],
+];
+
+print(`1..${tests.length}`);
+
+let failures = 0;
+
+tests.forEach(([name, testCase], index) => {
+    try {
+        testCase();
+        print(`ok ${index + 1} - ${name}`);
+    } catch (error) {
+        failures += 1;
+        print(`not ok ${index + 1} - ${name}`);
+        print(`# ${error.message}`);
+    }
+});
+
+System.exit(failures ? 1 : 0);


### PR DESCRIPTION
Fixes a crash when a menu item is moved past the last row a menu currently has: `moveItemInMenu()` appends it with `menu.box.add()`, which `St.BoxLayout` no longer provides, after having removed the row from the box, so the row is lost and gnome-shell logs a `TypeError`.

Fixes #649 — see the issue for the full analysis.

The first commit moves `moveItemInMenu()` into a module of its own, so that it can be tested without a running gnome-shell, and the second one adds a TAP test that reproduces the crash against a stand-in for the `St.BoxLayout` of a popup menu. It fails on the second commit and passes on the third, which carries the fix. `meson test` picks it up next to the linter, and the dist check installs `gjs` to run it.
