### PR TITLE
ci: Bump the actions still targeting Node.js 20

### DIFF
--- a/.github/workflows/dist-check-and-ego-upload.yaml
+++ b/.github/workflows/dist-check-and-ego-upload.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v5
 
     - name: Setup the container
       uses: canonical/desktop-engineering/gh-actions/common/dpkg-install-speedup@main
@@ -35,7 +35,7 @@ jobs:
         ninja -C _build zip-file
 
     - name: Save extension zip file
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v5
       with:
         name: extension-zip
         path: _build/*.zip

--- a/.github/workflows/eslint.yaml
+++ b/.github/workflows/eslint.yaml
@@ -4,7 +4,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v5
     - name: Install modules
       run: sudo npm install eslint@8.57.0 -g
     - name: Run ESLint


### PR DESCRIPTION
Silences the [Node.js 20 deprecation warning](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) the runners raise for `actions/checkout@v2` and `actions/upload-artifact@v4`.