### PR TITLE
ci: Run the dist check on pull requests

### DIFF
--- a/.github/workflows/dist-check-and-ego-upload.yaml
+++ b/.github/workflows/dist-check-and-ego-upload.yaml
@@ -2,11 +2,11 @@ name: Build Dist
 
 on:
   push:
-    pull_request:
     branches:
       - '*'
     tags:
       - '*'
+  pull_request:
 
 jobs:
   distcheck:


### PR DESCRIPTION
`pull_request` was nested under `push`, where it is ignored, so the dist check never ran on pull requests.

## Background Reading

GHA apparently doesn't do a schema check against its own specification. Hence, no error, no warning when you add a keyword in the wrong place. The documentation has no mention of `pull_request` nested in `push`, either.

- [GHA Events > `push`](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#push)
- [GHA Events > `pull_request`](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request)