### PR TITLE
locale/it: Replace placeholder values in the header

### DIFF
--- a/locale/it.po
+++ b/locale/it.po
@@ -1,15 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# Italian translation for AppIndicatorExtension.
+# Copyright (C) 2017-2025 AppIndicatorExtension's COPYRIGHT HOLDER
+# This file is distributed under the same license as the AppIndicatorExtension package.
+# Jimmy Scionti <jimmy.scionti@gmail.com>, 2017-2025.
 #
-#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: AppIndicatorExtension\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-07-27 10:15+0200\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2025-09-18 07:56+0200\n"
 "Last-Translator: Jimmy Scionti <jimmy.scionti@gmail.com>\n"
 "Language-Team: Jimmy Scionti <jimmy.scionti@gmail.com>\n"
 "Language: it_IT\n"


### PR DESCRIPTION
The Italian translation header still carries the msginit placeholders: `Project-Id-Version: PACKAGE VERSION`, `PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE` and the `SOME DESCRIPTIVE TITLE` / `FIRST AUTHOR` comment block (the charset line was already fixed in 4e294c0).

Replaced with real values, following the style of `ar.po`/`ka.po`. The revision date is the timestamp of the last actual translation update (0ba42a0). Dropped the `#, fuzzy` flag on the header entry, which msginit adds because of those placeholders.

`msgfmt --check` passes: 16 translated messages, no warnings.

Fixes #598