### PR TITLE
locale: Replace placeholder texts in the po file comments

### DIFF
--- a/locale/AppIndicatorExtension.pot
+++ b/locale/AppIndicatorExtension.pot
@@ -1,5 +1,5 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# Translations template for AppIndicatorExtension.
+# Copyright (C) 2025 AppIndicatorExtension translators
 # This file is distributed under the same license as the AppIndicatorExtension package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
@@ -14,7 +14,7 @@ msgstr ""
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
 #: preferences/generalPage.js:15

--- a/locale/ar.po
+++ b/locale/ar.po
@@ -3,7 +3,6 @@
 # This file is distributed under the same license as the AppIndicatorExtension package.
 # Ahmed Najmawi <iramosu@protonmail.com>,  2025.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: AppIndicatorExtension\n"

--- a/locale/ar.po
+++ b/locale/ar.po
@@ -1,7 +1,7 @@
 # Arabic translation for AppIndicatorExtension.
-# Copyright (C) 2025 AppIndicatorExtension's COPYRIGHT HOLDER
+# Copyright (C) 2025 AppIndicatorExtension translators
 # This file is distributed under the same license as the AppIndicatorExtension package.
-# Ahmed Najmawi <iramosu@protonmail.com>,  2025.
+# Ahmed Najmawi <iramosu@protonmail.com>, 2025.
 #
 msgid ""
 msgstr ""

--- a/locale/bg.po
+++ b/locale/bg.po
@@ -1,5 +1,5 @@
-# Bulgarian translation file
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# Bulgarian translation for AppIndicatorExtension.
+# Copyright (C) 2024-2025 AppIndicatorExtension translators
 # This file is distributed under the same license as the AppIndicatorExtension package.
 # Iliya Iliev <iliq0000@proton.me>, 2024-2025.
 #

--- a/locale/cs.po
+++ b/locale/cs.po
@@ -1,7 +1,8 @@
-# Czech translation of gnome-shell-extension-appindicator.
-# Copyright (C) 2022
+# Czech translation for AppIndicatorExtension.
+# Copyright (C) 2022-2025 AppIndicatorExtension translators
 # This file is distributed under the same license as the AppIndicatorExtension package.
 # Daniel Rusek <mail@asciiwolf.com>, 2022.
+# Ludek Vydra <lvtran@u.k2.cz>, 2024-2025.
 #
 msgid ""
 msgstr ""

--- a/locale/de.po
+++ b/locale/de.po
@@ -1,7 +1,7 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# German translation for AppIndicatorExtension.
+# Copyright (C) 2017 AppIndicatorExtension translators
+# This file is distributed under the same license as the AppIndicatorExtension package.
+# Jonatan Hatakeyama Zeidler <jonatan_zeidler@gmx.de>, 2017.
 #
 msgid ""
 msgstr ""

--- a/locale/fr.po
+++ b/locale/fr.po
@@ -1,7 +1,8 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# French translation for AppIndicatorExtension.
+# Copyright (C) 2017-2022 AppIndicatorExtension translators
+# This file is distributed under the same license as the AppIndicatorExtension package.
+# Jean-Christophe Baptiste <jc.baptiste@sysdream.com>, 2017.
+# roxfr <roxfr@outlook.fr>, 2022.
 #
 msgid ""
 msgstr ""

--- a/locale/hu.po
+++ b/locale/hu.po
@@ -1,7 +1,9 @@
 # Hungarian translation for AppIndicator GNOME Shell Extension.
+# Copyright (C) 2017 AppIndicatorExtension translators
 # Copyright (C) 2022, 2023 Free Software Foundation, Inc.
 # This file is distributed under the same license as the gnome-shell-extension-appindicator package.
 #
+# Falu <falu@gmx.us>, 2017.
 # Balázs Úr <ur.balazs at fsf dot hu>, 2022, 2023.
 msgid ""
 msgstr ""

--- a/locale/it.po
+++ b/locale/it.po
@@ -1,5 +1,5 @@
 # Italian translation for AppIndicatorExtension.
-# Copyright (C) 2017-2025 AppIndicatorExtension's COPYRIGHT HOLDER
+# Copyright (C) 2017-2025 AppIndicatorExtension translators
 # This file is distributed under the same license as the AppIndicatorExtension package.
 # Jimmy Scionti <jimmy.scionti@gmail.com>, 2017-2025.
 #

--- a/locale/ja.po
+++ b/locale/ja.po
@@ -1,7 +1,6 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# Japanese translation for AppIndicatorExtension.
+# Copyright (C) 2017 AppIndicatorExtension translators
+# This file is distributed under the same license as the AppIndicatorExtension package.
 #
 msgid ""
 msgstr ""

--- a/locale/ka.po
+++ b/locale/ka.po
@@ -1,9 +1,9 @@
 # Georgian translation for AppIndicatorExtension.
-# Copyright (C) 2025 AppIndicatorExtension's authors.
+# Copyright (C) 2025 AppIndicatorExtension translators
 # This file is distributed under the same license as the AppIndicatorExtension package.
 # Ekaterine Papava <papava.e@gtu.ge>, 2025.
+# Temuri Doghonadze <temuri.doghonadze@gmail.com>, 2025.
 #
-
 msgid ""
 msgstr ""
 "Project-Id-Version: AppIndicatorExtension\n"

--- a/locale/ko.po
+++ b/locale/ko.po
@@ -1,5 +1,5 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# Korean translation for AppIndicatorExtension.
+# Copyright (C) 2022 AppIndicatorExtension translators
 # This file is distributed under the same license as the AppIndicatorExtension package.
 # Junghee Lee <daemul72@gmail.com>, 2022.
 #

--- a/locale/nl.po
+++ b/locale/nl.po
@@ -1,7 +1,8 @@
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-#
+# Dutch translation for AppIndicatorExtension.
+# Copyright (C) 2019 AppIndicatorExtension translators
+# This file is distributed under the same license as the AppIndicatorExtension package.
 # Heimen Stoffels <vistausss@outlook.com>, 2019.
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"

--- a/locale/oc.po
+++ b/locale/oc.po
@@ -1,7 +1,7 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# Occitan translation for AppIndicatorExtension.
+# Copyright (C) 2022 AppIndicatorExtension translators
 # This file is distributed under the same license as the AppIndicatorExtension package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# Quentin PAGÈS, 2022.
 #
 msgid ""
 msgstr ""

--- a/locale/pl.po
+++ b/locale/pl.po
@@ -1,7 +1,8 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# Polish translation for AppIndicatorExtension.
+# Copyright (C) 2022-2023 AppIndicatorExtension translators
 # This file is distributed under the same license as the AppIndicatorExtension package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# HydeFromT70s, 2022.
+# Maciej Karpinski <kontakt@karpinski.tech>, 2023.
 #
 msgid ""
 msgstr ""

--- a/locale/pt_BR.po
+++ b/locale/pt_BR.po
@@ -1,12 +1,12 @@
-# Brazilian Portuguese translations for TopIcons-Plus package
-# Traduções em português brasileiro para o pacote TopIcons-Plus.
-# Copyright (C) 2019 THE TopIcons-Plus'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the TopIcons-Plus package.
+# Brazilian Portuguese translation for AppIndicatorExtension.
+# Traduções em português brasileiro para o pacote AppIndicatorExtension.
+# Copyright (C) 2019 AppIndicatorExtension translators
+# This file is distributed under the same license as the AppIndicatorExtension package.
 # Rafael Fontenelle <rafaelff@gnome.org>, 2019.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: TopIcons-Plus\n"
+"Project-Id-Version: AppIndicatorExtension\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2021-09-27 20:43+0200\n"
 "PO-Revision-Date: 2019-04-17 23:02-0300\n"

--- a/locale/ru.po
+++ b/locale/ru.po
@@ -1,9 +1,10 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# Russian translation for AppIndicatorExtension.
+# Copyright (C) 2017-2025 AppIndicatorExtension translators
 # This file is distributed under the same license as the AppIndicatorExtension package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# Alex Gluck <alexgluck@bk.ru>, 2017.
+# Aleksandr Melman <Alexmelman88@gmail.com>, 2022-2023.
+# Fraxinus Acer, 2025.
 #
-#, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: AppIndicatorExtension\n"

--- a/locale/sk.po
+++ b/locale/sk.po
@@ -1,5 +1,5 @@
-# Slovak translation of gnome-shell-extension-appindicator.
-# Copyright (C) 2022
+# Slovak translation for AppIndicatorExtension.
+# Copyright (C) 2022 AppIndicatorExtension translators
 # This file is distributed under the same license as the AppIndicatorExtension package.
 # Jose Riha <jose1711 gmail com>, 2022.
 #

--- a/locale/sr.po
+++ b/locale/sr.po
@@ -1,7 +1,7 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# Serbian translation for AppIndicatorExtension.
+# Copyright (C) 2017 AppIndicatorExtension translators
+# This file is distributed under the same license as the AppIndicatorExtension package.
+# Xabre <Xabre@archlinux.info>, 2017.
 #
 msgid ""
 msgstr ""

--- a/locale/sr@latin.po
+++ b/locale/sr@latin.po
@@ -1,7 +1,7 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# Serbian (Latin) translation for AppIndicatorExtension.
+# Copyright (C) 2017 AppIndicatorExtension translators
+# This file is distributed under the same license as the AppIndicatorExtension package.
+# Xabre <Xabre@archlinux.info>, 2017.
 #
 msgid ""
 msgstr ""

--- a/locale/tr.po
+++ b/locale/tr.po
@@ -1,13 +1,13 @@
-# Ubuntu AppIndicator Turkish Translate.
-# Copyright (C) 2019-2023 Ubuntu AppIndicator'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the Ubuntu AppIndicator package.
+# Turkish translation for AppIndicatorExtension.
+# Copyright (C) 2019-2023 AppIndicatorExtension translators
+# This file is distributed under the same license as the AppIndicatorExtension package.
 #
 # Serdar Sağlam <teknomobil@yandex.com>, 2019.
 # Sabri Ünal <libreajans@gmail.com>, 2023.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Ubuntu AppIndicator\n"
+"Project-Id-Version: AppIndicatorExtension\n"
 "Report-Msgid-Bugs-To: https://github.com/ubuntu/gnome-shell-extension-appindicator\n"
 "POT-Creation-Date: 2023-03-07 02:36+0100\n"
 "PO-Revision-Date: 2023-04-20 12:56+0300\n"

--- a/locale/zh_CN.po
+++ b/locale/zh_CN.po
@@ -1,11 +1,12 @@
-# Chinese (China) translation for TopIcons-Plus.
-# Copyright (C) 2017-2017 TopIcons-Plus's COPYRIGHT HOLDER
-# This file is distributed under the same license as the TopIcons-Plus package.
+# Chinese (China) translation for AppIndicatorExtension.
+# Copyright (C) 2017-2023 AppIndicatorExtension translators
+# This file is distributed under the same license as the AppIndicatorExtension package.
 # Dingzhong Chen <wsxy162@gmail.com>, 2017.
+# Dee.H.Y <dongfengweixiao@hotmail.com>, 2023.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: TopIcons-Plus master\n"
+"Project-Id-Version: AppIndicatorExtension\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2023-03-07 02:36+0100\n"
 "PO-Revision-Date: 2023-07-08 15:34+0800\n"

--- a/locale/zh_TW.po
+++ b/locale/zh_TW.po
@@ -1,7 +1,7 @@
-# Chinese translations for AppIndicatorExtension package.
-# Copyright (C) 2024 THE AppIndicatorExtension'S COPYRIGHT HOLDER
+# Chinese (Traditional) translation for AppIndicatorExtension.
+# Copyright (C) 2024 AppIndicatorExtension translators
 # This file is distributed under the same license as the AppIndicatorExtension package.
-# Peter Hsu <hsu@peterdavehello.org>, 2024.
+# Peter Dave Hello <hsu@peterdavehello.org>, 2024.
 #
 msgid ""
 msgstr ""


### PR DESCRIPTION
Follow-up to #658, which fixes the header values of `it.po` (#598). The same msginit placeholders (`SOME DESCRIPTIVE TITLE`, `YEAR THE PACKAGE'S COPYRIGHT HOLDER`, `the PACKAGE package`, `FIRST AUTHOR <EMAIL@ADDRESS>`) are still present in the comment blocks of 11 more files.

Replaced with the actual title, copyright years, package name and translators, taken from the `Last-Translator` header and the file history. For `ja`, `sr` and `sr@latin` no translator is recorded anywhere, so the author line is left out rather than guessed.

Also:
- `AppIndicatorExtension.pot`: charset set to UTF-8, so translations initialized from the template no longer inherit the `CHARSET` placeholder that broke the build in #598. Note that regenerating the template with meson will restore the xgettext defaults; passing `--copyright-holder`/`--package-name` in `locale/meson.build` would make this durable, happy to add that if wanted.
- `ar.po`, `ru.po`: dropped the stale `#, fuzzy` flag on the header entry, whose headers are complete.

No message content is touched. `msgfmt --check` passes for all files.

Unrelated, so not touched here: `nl.po` declares `"Language: de\n"`.